### PR TITLE
WIP Add kontian specialization code to crun

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -33,7 +33,8 @@ libcrun_SOURCES = src/libcrun/utils.c \
 			src/libcrun/terminal.c \
 			src/libcrun/chroot_realpath.c \
 			src/libcrun/signals.c \
-			src/libcrun/seccomp_notify.c
+			src/libcrun/seccomp_notify.c \
+			src/libcrun/kontain.c
 
 
 libcrun_la_SOURCES = $(libcrun_SOURCES)
@@ -57,7 +58,7 @@ endif
 crun_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src
 crun_SOURCES = src/crun.c src/run.c src/delete.c src/kill.c src/pause.c src/unpause.c src/spec.c \
 		src/exec.c src/list.c src/create.c src/start.c src/state.c src/update.c src/ps.c \
-		src/checkpoint.c src/restore.c
+		src/checkpoint.c src/restore.c src/kontain.c src/debug.c
 crun_LDADD = libcrun.la $(FOUND_LIBS)
 crun_LDFLAGS = $(CRUN_LDFLAGS)
 

--- a/src/create.c
+++ b/src/create.c
@@ -25,8 +25,11 @@
 #include <errno.h>
 
 #include "crun.h"
+#include "kontain.h"
+#include "debug.h"
 #include "libcrun/container.h"
 #include "libcrun/utils.h"
+#include "libcrun/status.h"
 
 enum
 {
@@ -159,6 +162,14 @@ crun_command_create (struct crun_global_arguments *global_args, int argc, char *
   container = libcrun_container_load_from_file (config_file, err);
   if (container == NULL)
     libcrun_fail_with_error (0, "error loading config.json");
+
+  if (crun_context.kontain) {
+    ret = add_kontain_config(container);
+    if (ret < 0) {
+      libcrun_fail_with_error(0, "adding kontain bind mounts");
+      return ret;
+    }
+  }
 
   crun_context.bundle = bundle ? bundle : ".";
   if (getenv ("LISTEN_FDS"))

--- a/src/crun.c
+++ b/src/crun.c
@@ -41,6 +41,7 @@
 #include "ps.h"
 #include "checkpoint.h"
 #include "restore.h"
+#include "debug.h"
 
 static struct crun_global_arguments arguments;
 
@@ -79,6 +80,8 @@ init_libcrun_context (libcrun_context_t *con, const char *id, struct crun_global
 
   if (con->config_file == NULL)
     con->config_file = "./config.json";
+
+  con->kontain = glob->kontain;
 
   return 0;
 }
@@ -293,9 +296,26 @@ main (int argc, char **argv)
   libcrun_error_t err = NULL;
   int ret, first_argument;
 
+FILE *tf = fopen("/tmp/kontain_crun_trace.out", "a");
+for (int i = 0; i < argc; i++) {
+  fprintf(tf, "argv[%d] = %s\n", i, argv[i]);
+}
+fclose(tf);
+
+  char *cmd = strrchr(argv[0], '/');
+  if (cmd == NULL) {
+    cmd = argv[0];
+  } else {
+    cmd++;
+  }
+  if (strcmp(cmd, "krun") == 0) {
+     arguments.kontain = true;
+  }
+
   argp_program_version_hook = print_version;
 
   argp_parse (&argp, argc, argv, ARGP_IN_ORDER, &first_argument, &arguments);
+debug("argv[0] %s, command %s, arguments.kontain %d\n", argv[0], argv[first_argument], arguments.kontain);
 
   command = get_command (argv[first_argument]);
   if (command == NULL)

--- a/src/debug.c
+++ b/src/debug.c
@@ -1,0 +1,159 @@
+#include <config.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <argp.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <errno.h>
+#include <stdarg.h>
+#include <sys/sysmacros.h>
+
+#include "crun.h"
+#include "libcrun/container.h"
+#include "libcrun/utils.h"
+
+#define TRACE_FILE "/tmp/kontain_crun_trace.out"
+FILE *tracefile;
+
+void
+debug_open_tracefile(void)
+{
+   if (tracefile == NULL) {
+      tracefile = fopen(TRACE_FILE, "a");
+      if (tracefile == NULL) {
+         abort();
+      }
+   }
+}
+
+void debug(char *fmt, ...)
+{
+   va_list ap;
+
+   debug_open_tracefile();
+   va_start(ap, fmt);
+   vfprintf(tracefile, fmt, ap);
+   va_end(ap);
+}
+
+void
+dumpmounts(libcrun_container_t *container)
+{
+   runtime_spec_schema_config_schema *container_def = container->container_def;
+   int i;
+
+   debug_open_tracefile();
+
+   for (i = 0; i < container_def->mounts_len; i++) {
+      fprintf(tracefile, "mount[%d]: source %s, destination %s, type %s, options_len %d\n",
+         i, container_def->mounts[i]->source, container_def->mounts[i]->destination,
+         container_def->mounts[i]->type, container_def->mounts[i]->options_len);
+      for (int j = 0; j < container_def->mounts[i]->options_len; j++) {
+         fprintf(tracefile, "options[%d]: %s\n", j, container_def->mounts[i]->options[j]);
+      }
+   }
+   fflush(tracefile);
+}
+
+void
+dumpdevices(libcrun_container_t *container)
+{
+   runtime_spec_schema_config_schema *container_def = container->container_def;
+
+   debug_open_tracefile();
+
+   for (int i = 0; i < container_def->linux->devices_len; i++) {
+      fprintf(tracefile, "devices[%d]: type %s, path %s, "
+                     "file_mode 0%o, file_mode_present %u, "
+                     "major %ld, major_present %u, "
+                     "minor %ld, minor_present %u, "
+                     "uid %ld, uid_present %u, "
+                     "gid %ld, gid_present %u\n",
+         i,
+         container_def->linux->devices[i]->type,
+         container_def->linux->devices[i]->path,
+         container_def->linux->devices[i]->file_mode,
+         container_def->linux->devices[i]->file_mode_present,
+         container_def->linux->devices[i]->major,
+         container_def->linux->devices[i]->major_present,
+         container_def->linux->devices[i]->minor,
+         container_def->linux->devices[i]->minor_present,
+         container_def->linux->devices[i]->uid,
+         container_def->linux->devices[i]->uid_present,
+         container_def->linux->devices[i]->gid,
+         container_def->linux->devices[i]->gid_present);
+   }
+   fflush(tracefile);
+}
+
+void
+dumpannotations(libcrun_container_t *container)
+{
+  runtime_spec_schema_config_schema *container_def = container->container_def;
+
+  debug_open_tracefile();
+
+  fprintf(tracefile, "Begin annotations\n");
+  if (container_def->annotations != NULL) {
+    for (int i = 0; i < container_def->annotations->len; i++) {
+      fprintf(tracefile, "%s = %s\n", container_def->annotations->keys[i], container_def->annotations->values[i]);
+    }
+  }
+  fprintf(tracefile, "End annotations\n");
+
+  fflush(tracefile);
+}
+
+void
+dumpconfig(const char *config_file)
+{
+  FILE *config;
+  char buffer[16*1024];
+
+  config = fopen(config_file, "r");
+  debug_open_tracefile();
+
+  fprintf(tracefile, "Begin %s\n", config_file);
+  while (fgets(buffer, sizeof(buffer), config) != NULL) {
+    fputs(buffer, tracefile);
+  }
+  fprintf(tracefile, "\nEnd %s\n", config_file);
+
+  fclose(config);
+  fflush(tracefile);
+}
+
+
+void
+runtime_spec_to_file(runtime_spec_schema_config_schema *container)
+{
+  parser_error err;
+  char *json_buf = NULL;
+
+  json_buf = runtime_spec_schema_config_schema_generate_json(container, 0, &err);
+  if (json_buf == NULL) {
+    libcrun_fail_with_error(0, err);
+    return;
+  }
+
+  debug_open_tracefile();
+
+  fputs(json_buf, tracefile);
+
+  free(json_buf);
+}
+
+void
+dump_crun_context(libcrun_context_t *context)
+{
+  char cwd[PATH_MAX];
+
+  debug_open_tracefile();
+  getcwd(cwd, sizeof(cwd));
+  fprintf(tracefile, "cwd %s\n", cwd);
+  fprintf(tracefile, "state_root %s, id %s, bundle %s, config_file %s, pid_file %s, notify_socket %s\n",
+    context->state_root, context->id, context->bundle, context->config_file, context->pid_file, context->notify_socket);
+  fflush(tracefile);
+}

--- a/src/debug.c
+++ b/src/debug.c
@@ -47,7 +47,7 @@ dumpmounts(libcrun_container_t *container)
    debug_open_tracefile();
 
    for (i = 0; i < container_def->mounts_len; i++) {
-      fprintf(tracefile, "mount[%d]: source %s, destination %s, type %s, options_len %d\n",
+      fprintf(tracefile, "mount[%d]: source %s, destination %s, type %s, options_len %lu\n",
          i, container_def->mounts[i]->source, container_def->mounts[i]->destination,
          container_def->mounts[i]->type, container_def->mounts[i]->options_len);
       for (int j = 0; j < container_def->mounts[i]->options_len; j++) {
@@ -69,8 +69,8 @@ dumpdevices(libcrun_container_t *container)
                      "file_mode 0%o, file_mode_present %u, "
                      "major %ld, major_present %u, "
                      "minor %ld, minor_present %u, "
-                     "uid %ld, uid_present %u, "
-                     "gid %ld, gid_present %u\n",
+                     "uid %u, uid_present %u, "
+                     "gid %u, gid_present %u\n",
          i,
          container_def->linux->devices[i]->type,
          container_def->linux->devices[i]->path,

--- a/src/debug.h
+++ b/src/debug.h
@@ -1,7 +1,7 @@
 /*
  * crun - OCI runtime written in C
  *
- * Copyright (C) 2017, 2018, 2019 Giuseppe Scrivano <giuseppe@scrivano.org>
+ * Copyright (C) 2020 Kontain Inc.
  * crun is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -15,26 +15,17 @@
  * You should have received a copy of the GNU General Public License
  * along with crun.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef CRUN_H
-#define CRUN_H
+#ifndef DEBUG_H
+#define DEBUG_H
 
-#include "libcrun/container.h"
+#include "crun.h"
 
-struct crun_global_arguments
-{
-  char *root;
-  char *log;
-  char *log_format;
+void dumpmounts(libcrun_container_t *container);
+void dumpdevices(libcrun_container_t *container);
+void dumpannotations(libcrun_container_t *container);
+void dumpconfig(const char *config_file);
+void runtime_spec_to_file(runtime_spec_schema_config_schema *container);
+void dump_crun_context(libcrun_context_t *context);
+void debug(char *fmt, ...);
 
-  bool command;
-  bool debug;
-  bool option_systemd_cgroup;
-  bool option_force_no_cgroup;
-  bool kontain;
-};
-
-char *argp_mandatory_argument (char *arg, struct argp_state *state);
-int init_libcrun_context (libcrun_context_t *con, const char *id, struct crun_global_arguments *glob,
-                          libcrun_error_t *err);
-void crun_assert_n_args (int n, int min, int max);
 #endif

--- a/src/kontain.c
+++ b/src/kontain.c
@@ -1,0 +1,218 @@
+/*
+ * crun - OCI runtime written in C
+ *
+ * Copyright (C) 2020 Kontain Inc.
+ * crun is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * crun is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with crun.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <config.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <argp.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <errno.h>
+#include <sys/sysmacros.h>
+
+#include "crun.h"
+#include "kontain.h"
+#include "debug.h"
+#include "libcrun/container.h"
+#include "libcrun/utils.h"
+
+static runtime_spec_schema_defs_mount *
+build_kontain_bind_mount(char *src, char *dst)
+{
+  runtime_spec_schema_defs_mount *m = calloc(1, sizeof(runtime_spec_schema_defs_mount));
+  if (m != NULL) {
+    m->source = strdup(src);
+    m->destination = strdup(dst);
+#define BIND_MOUNT_OPTIONS_COUNT 2
+    m->options = calloc(BIND_MOUNT_OPTIONS_COUNT, sizeof(char *));
+    m->options[0] = strdup("rbind");
+    m->options[1] = strdup("rprivate");
+    m->options_len = BIND_MOUNT_OPTIONS_COUNT;
+    m->type = strdup("bind");
+  }
+  return m;
+}
+
+int
+add_kontain_bind_mounts(libcrun_container_t *container, const char *privileged)
+{
+  runtime_spec_schema_config_schema *container_def = container->container_def;
+  runtime_spec_schema_defs_mount **mounts = container_def->mounts;
+  int mounts_len = container_def->mounts_len;
+  int kvmkkm_bind_mount = 0;
+
+  // for unprivileged podman we bind mount /dev/kvm or /dev/kkm
+  if (privileged != NULL && strcasecmp(privileged, "false") == 0) {
+    kvmkkm_bind_mount = 1;
+  }
+
+  int new_mounts_len = mounts_len + 2 + kvmkkm_bind_mount;
+  runtime_spec_schema_defs_mount **new_mounts = realloc(mounts, new_mounts_len * sizeof(runtime_spec_schema_defs_mount *));
+  if (new_mounts == NULL) {
+    return ENOMEM;
+  }
+  container_def->mounts = new_mounts;
+  container_def->mounts[mounts_len] = build_kontain_bind_mount("/opt/kontain/bin/km", "/opt/kontain/bin/km");
+  if (container_def->mounts[mounts_len] == NULL)
+    return ENOMEM;
+  container_def->mounts[mounts_len + 1] = build_kontain_bind_mount("/opt/kontain/runtime/libc.so", "/opt/kontain/runtime/libc.so");
+  if (container_def->mounts[mounts_len + 1] == NULL)
+    return ENOMEM;
+  if (kvmkkm_bind_mount != 0) {
+    container_def->mounts[mounts_len + 2] = build_kontain_bind_mount("/dev/kvm", "/dev/kvm");
+    if (container_def->mounts[mounts_len + 2] == NULL)
+      return ENOMEM;
+  }
+  container_def->mounts_len = new_mounts_len;
+
+  return 0;
+}
+
+int
+build_kontain_device(char *devpath,
+   runtime_spec_schema_defs_linux_device **devp,
+   runtime_spec_schema_defs_linux_device_cgroup **accessp)
+{
+  struct stat statb;
+  runtime_spec_schema_defs_linux_device *dev = NULL;
+  runtime_spec_schema_defs_linux_device_cgroup *access = NULL;
+  int ret = 0;
+
+  if (stat(devpath, &statb) == 0) {
+    dev = calloc(1, sizeof(runtime_spec_schema_defs_linux_device));
+    if (dev == NULL) {
+      return ENOMEM;
+    }
+    access = calloc(1, sizeof(runtime_spec_schema_defs_linux_device_cgroup));
+    if (access == NULL) {
+      return ENOMEM;
+    }
+
+    // Build the device
+    switch (statb.st_mode & S_IFMT) {
+    case S_IFBLK:
+      dev->type = strdup("b");
+      break;
+    case S_IFCHR:
+      dev->type = strdup("c");
+      break;
+    case S_IFIFO:
+      dev->type = strdup("p");
+      break;
+    default:
+      free(dev);
+      free(access);
+      return EINVAL;
+      break;
+    }
+    dev->path = strdup(devpath);
+    dev->file_mode_present = 1;
+    dev->file_mode = statb.st_mode;
+    dev->major_present = 1;
+    dev->major = major(statb.st_rdev);
+    dev->minor_present = 1;
+    dev->minor = minor(statb.st_rdev);
+    dev->uid_present  = 1;
+    dev->uid = statb.st_uid;
+    dev->gid_present = 1;
+    dev->gid = statb.st_gid;
+
+     // Build the granted access
+     access->allow = 1;
+     access->allow_present = 1;
+     access->type = strdup(dev->type);
+     access->major = dev->major;
+     access->major_present = 1;
+     access->minor = dev->minor;
+     access->minor_present = 1;
+     access->access = strdup("rwm");
+
+     *devp = dev;
+     *accessp = access;
+  } else {
+    ret = errno;
+  }
+  return ret;
+}
+
+int
+add_kontain_devices(libcrun_container_t *container, const char *use_virt)
+{
+  runtime_spec_schema_config_schema *container_def = container->container_def;
+  runtime_spec_schema_config_linux *linux = container_def->linux;
+  runtime_spec_schema_defs_linux_device *dev;
+  runtime_spec_schema_defs_linux_device_cgroup *access;
+  int ret = ENODEV;
+
+  if (strcmp(use_virt, "kvm") == 0) {
+    ret = build_kontain_device("/dev/kvm", &dev, &access);
+  } else if (strcmp(use_virt, "kkm") == 0) {
+    ret = build_kontain_device("/dev/kkm", &dev, &access);
+  }
+  if (ret != 0) {
+    return ret;
+  }
+
+  // Grow devices array
+  size_t new_devices_len = linux->devices_len + 1;
+  runtime_spec_schema_defs_linux_device **new_devices = realloc(linux->devices, new_devices_len * sizeof(runtime_spec_schema_defs_linux_device **));
+  if (new_devices == NULL) {
+    return ENOMEM;
+  }
+  new_devices[linux->devices_len] = dev;
+  linux->devices = new_devices;
+  linux->devices_len = new_devices_len;
+
+  // Grow access array
+  size_t new_res_devices_len = linux->resources->devices_len + 1;
+  runtime_spec_schema_defs_linux_device_cgroup **new_res_devices = realloc(linux->resources->devices, new_res_devices_len * sizeof(runtime_spec_schema_defs_linux_device_cgroup));
+  if (new_res_devices == NULL) {
+    return ENOMEM;
+  }
+  new_res_devices[linux->resources->devices_len] = access;
+  linux->resources->devices = new_res_devices;
+  linux->resources->devices_len = new_res_devices_len;
+
+  return 0;
+}
+
+int
+add_kontain_config(libcrun_container_t *container)
+{
+  int ret;
+  const char *use_virt = find_annotation(container, APP_KONTAIN_USEVIRT);
+  if (use_virt == NULL) {
+    libcrun_warning("Couldn't find %s annotation, using kvm", APP_KONTAIN_USEVIRT);
+    use_virt = "kvm";
+  }
+
+  const char *privileged = find_annotation(container, "io.podman.annotations.privileged");
+
+  ret = add_kontain_bind_mounts(container, privileged);
+  if (ret != 0) {
+    return ret;
+  }
+
+  // For docker or privileged podman, we create the /dev/kvm or kkm device.
+  if (privileged == NULL || strcasecmp(privileged, "true") == 0) {
+    ret = add_kontain_devices(container, use_virt);
+  }
+  return ret;
+}

--- a/src/kontain.h
+++ b/src/kontain.h
@@ -1,7 +1,7 @@
 /*
  * crun - OCI runtime written in C
  *
- * Copyright (C) 2017, 2018, 2019 Giuseppe Scrivano <giuseppe@scrivano.org>
+ * Copyright (C) 2020 Kontain Inc.
  * crun is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -15,26 +15,12 @@
  * You should have received a copy of the GNU General Public License
  * along with crun.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef CRUN_H
-#define CRUN_H
+#ifndef KONTAIN_H
+#define KONTAIN_H
 
-#include "libcrun/container.h"
+#include "crun.h"
 
-struct crun_global_arguments
-{
-  char *root;
-  char *log;
-  char *log_format;
+#define APP_KONTAIN_USEVIRT "app.kontain.use-virt"
+int add_kontain_config(libcrun_container_t *container);
 
-  bool command;
-  bool debug;
-  bool option_systemd_cgroup;
-  bool option_force_no_cgroup;
-  bool kontain;
-};
-
-char *argp_mandatory_argument (char *arg, struct argp_state *state);
-int init_libcrun_context (libcrun_context_t *con, const char *id, struct crun_global_arguments *glob,
-                          libcrun_error_t *err);
-void crun_assert_n_args (int n, int min, int max);
 #endif

--- a/src/libcrun/container.h
+++ b/src/libcrun/container.h
@@ -45,6 +45,7 @@ struct libcrun_context_s
   bool no_new_keyring;
   bool force_no_cgroup;
   bool no_pivot;
+  bool kontain;
 };
 
 enum

--- a/src/libcrun/kontain.c
+++ b/src/libcrun/kontain.c
@@ -1,0 +1,134 @@
+/*
+ * crun - OCI runtime written in C
+ *
+ * Copyright (C) 2020 Kontain Inc.
+ * crun is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * crun is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with crun.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <config.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <argp.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+#include <sys/sysmacros.h>
+
+#include "kontain.h"
+#include "container.h"
+#include "utils.h"
+
+/*
+ * If execpath is not a symlink to km or the path to km, then assume we
+ * are to run execpath as a km payload.  In this case add km's path to argv[0]
+ * and shift argv[0 ... n] up to argv[1 ... (n+1)] and return the absolute
+ * path to km.
+ * Arguments:
+ *   argv[] is terminated with a null pointer.
+ *   execpath - the program the caller wants to run, absolute path
+ * Returns:
+ *   0 - success
+ *   errno - failure
+ */
+int libcrun_kontain_argv(char ***argv, const char **execpath)
+{
+   struct stat statb;
+   char **newargv;
+   const char *cmd = *execpath;
+
+FILE *tf = fopen("/tmp/kontain_crun_trace.out", "a");
+fprintf(tf, "%s: argv %p, execpath %p\n", __FUNCTION__, argv, execpath);
+fflush(tf);
+fprintf(tf, "execpath %p, %s\n", execpath, *execpath);
+fflush(tf);
+#if 1
+for (int i = 0; (*argv)[i] != NULL; i++) {
+  fprintf(tf, "argv[%d] = %s\n", i, (*argv)[i]);
+  fflush(tf);
+}
+#endif
+fprintf(tf, "done looking at argv[]\n");
+fflush(tf);
+
+fprintf(tf, "cmd %s\n", cmd);
+fflush(tf);
+   if (cmd[0] != '/') {  // verify that we are getting an absolute path
+      return EINVAL;
+   }
+   if (fstatat(AT_FDCWD, cmd, &statb, AT_SYMLINK_NOFOLLOW) != 0) {
+      // the command does not exist?  Let the caller handle that.
+fprintf(tf, "stat(cmd) failed, errno %d\n", errno);
+fflush(tf);
+      return errno;
+   }
+fprintf(tf, "%s: st_mode 0%o\n", cmd, statb.st_mode);
+fflush(tf);
+   if ((statb.st_mode & S_IFMT) == S_IFLNK) {
+      char linkcontents[PATH_MAX];
+      while ((statb.st_mode & S_IFMT) == S_IFLNK) {
+         int rc = readlink(cmd, linkcontents, sizeof(linkcontents));
+fprintf(tf, "readlink %s returned %d\n", cmd, rc);
+fflush(tf);
+         if (rc < 0) {
+            return errno;
+         }
+         linkcontents[rc] = 0;
+         if (strcmp(linkcontents, KM_BIN_PATH) == 0) {
+            // symlink to km, ok
+            return 0;
+         }
+         if (fstatat(AT_FDCWD, linkcontents, &statb, AT_SYMLINK_NOFOLLOW) != 0) {
+            return errno;
+         }
+         cmd = linkcontents;
+      }
+      // symlink to something other than km, stuff km in front of argv[0]
+   } else if (strcmp(cmd, KM_BIN_PATH) == 0) {
+      // The command is km, nothing more to do.
+      return 0;
+   }
+
+   /* Some program other than km, assume they need km to run it so insert the path to km into argv[] */
+   int argc;
+   for (argc = 0; argv[argc] != NULL; argc++);
+   argc++;  // for null array terminator
+
+   // grow argv[]
+   newargv = malloc((argc + 1) * sizeof(char*));
+   if (newargv == NULL) {
+      return ENOMEM;
+   }
+
+   // Set km to the program that is to be run, it will run the former argv[0]
+   newargv[0] = strdup(KM_BIN_PATH);
+   for (int i = 0; i <= argc; i++) {
+      newargv[i + 1] = *argv[i];
+   }
+
+   // replace the payload filename and set the execpath to km's path
+   free(newargv[1]);
+   newargv[1] = (char *)*execpath;
+   *execpath = strdup(KM_BIN_PATH);
+
+   // Give the caller the new argv[]
+   char **oldargv = *argv;
+   *argv = newargv;
+   free(oldargv);
+
+fprintf(tf, "%s: done\n", __FUNCTION__);
+   return 0;
+}

--- a/src/libcrun/kontain.h
+++ b/src/libcrun/kontain.h
@@ -1,7 +1,7 @@
 /*
  * crun - OCI runtime written in C
  *
- * Copyright (C) 2017, 2018, 2019 Giuseppe Scrivano <giuseppe@scrivano.org>
+ * Copyright (C) 2020 Kontain Inc.
  * crun is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -15,26 +15,10 @@
  * You should have received a copy of the GNU General Public License
  * along with crun.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef CRUN_H
-#define CRUN_H
+#ifndef KONTAIN_H
+#define KONTAIN_H
 
-#include "libcrun/container.h"
+#define KM_BIN_PATH "/opt/kontain/bin/km"
+int libcrun_kontain_argv(char ***argv, const char **execpath);
 
-struct crun_global_arguments
-{
-  char *root;
-  char *log;
-  char *log_format;
-
-  bool command;
-  bool debug;
-  bool option_systemd_cgroup;
-  bool option_force_no_cgroup;
-  bool kontain;
-};
-
-char *argp_mandatory_argument (char *arg, struct argp_state *state);
-int init_libcrun_context (libcrun_context_t *con, const char *id, struct crun_global_arguments *glob,
-                          libcrun_error_t *err);
-void crun_assert_n_args (int n, int min, int max);
 #endif

--- a/src/run.c
+++ b/src/run.c
@@ -27,6 +27,7 @@
 #include "crun.h"
 #include "libcrun/container.h"
 #include "libcrun/utils.h"
+#include "kontain.h"
 
 static char doc[] = "OCI runtime";
 
@@ -164,6 +165,13 @@ crun_command_run (struct crun_global_arguments *global_args, int argc, char **ar
   ret = init_libcrun_context (&crun_context, argv[first_arg], global_args, err);
   if (UNLIKELY (ret < 0))
     return ret;
+
+  if (crun_context.kontain) {
+    ret = add_kontain_config(container);
+    if (ret < 0) {
+      libcrun_fail_with_error(0, "adding kontain bind mounts");
+    }
+  }
 
   crun_context.bundle = bundle ? bundle : ".";
   if (getenv ("LISTEN_FDS"))


### PR DESCRIPTION
This code adds the following:
- when crun is invoked with a symlink named krun that points to crun, crun will
  add bind mounts for /opt/kontain/runtime/libc.so, /opt/kontain/bin/km, and /dev/kvm (or /dev/kkm)
  to the config.json file for the container.  There is no need to add -v options on the krun
  command line to create these.
- when starting the entry point to the container, if the command being executed in not /opt/kontain/bin/km
  or a series of symlinks that resolve to km, then we insert /opt/kontain/bin/km into into the argument
  list before all of the existing command line arguments.
- There is some crude debug code in here that is not permanent.

This has been lightly tested by using "podman pull" to get a copy of "docker.io/kontain/runenv-python  latest"
into podman's "registry". Then  "podman start" has been run to verify that the python sanity test program runs in
a podman container.
I also played around with "podman create" followed by "podman start" and that worked although it did things I
didn't expect.  "podman create"  does not start the container and keep it paused until "podman start" is issued.
"podman create" just sets up the filesystem hierarchy for the container.  The "podman start" does the "krun create",
"krun start", and then "krun delete".
Have not tested "podman exec" yet.