### PR TITLE
Ignore the crun test *.prs and *.log files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,5 @@ stamp-h1
 tests/init
 tests/tests_libcrun_errors
 tests/tests_libcrun_utils
+tests/*.log
+tests/*.trs


### PR DESCRIPTION
Tested by running "git status" and not seeing all the test result files.