### PR TITLE
Fix crun to work using km to run container payload.

### DIFF
--- a/src/crun.c
+++ b/src/crun.c
@@ -296,12 +296,6 @@ main (int argc, char **argv)
   libcrun_error_t err = NULL;
   int ret, first_argument;
 
-FILE *tf = fopen("/tmp/kontain_crun_trace.out", "a");
-for (int i = 0; i < argc; i++) {
-  fprintf(tf, "argv[%d] = %s\n", i, argv[i]);
-}
-fclose(tf);
-
   char *cmd = strrchr(argv[0], '/');
   if (cmd == NULL) {
     cmd = argv[0];
@@ -315,7 +309,6 @@ fclose(tf);
   argp_program_version_hook = print_version;
 
   argp_parse (&argp, argc, argv, ARGP_IN_ORDER, &first_argument, &arguments);
-debug("argv[0] %s, command %s, arguments.kontain %d\n", argv[0], argv[first_argument], arguments.kontain);
 
   command = get_command (argv[first_argument]);
   if (command == NULL)

--- a/src/kontain.c
+++ b/src/kontain.c
@@ -170,6 +170,14 @@ add_kontain_devices(libcrun_container_t *container, const char *use_virt)
     return ret;
   }
 
+  // No resources, make an empty one of those first
+  if (linux->resources == NULL) {
+    linux->resources = calloc(1, sizeof(*linux->resources));
+    if (linux->resources == NULL) {
+      return ENOMEM;
+    }
+  }
+
   // Grow devices array
   size_t new_devices_len = linux->devices_len + 1;
   runtime_spec_schema_defs_linux_device **new_devices = realloc(linux->devices, new_devices_len * sizeof(runtime_spec_schema_defs_linux_device **));

--- a/tests/tests_utils.py
+++ b/tests/tests_utils.py
@@ -176,7 +176,7 @@ def run_all_tests(all_tests, allowed_tests):
                 print("not ok %d - %s" % (cur, k))
         except Exception as e:
             if hasattr(e, 'output'):
-                sys.stderr.write(str(e.output) + "\n")
+                sys.stderr.write(e.output.decode('UTF-8'))
             sys.stderr.write(str(e) + "\n")
             ret = -1
             print("not ok %d - %s" % (cur, k))
@@ -194,7 +194,7 @@ def run_and_get_output(config, detach=False, preserve_fds=None, pid_file=None,
     temp_dir = tempfile.mkdtemp(dir=get_tests_root())
     rootfs = os.path.join(temp_dir, "rootfs")
     os.makedirs(rootfs)
-    for i in ["usr/bin", "etc", "var", "lib", "lib64", "usr/share/zoneinfo/Europe"]:
+    for i in ["usr/bin", "sbin", "etc", "var", "lib", "lib64", "usr/share/zoneinfo/Europe"]:
         os.makedirs(os.path.join(rootfs, i))
     with open(os.path.join(rootfs, "var", "file"), "w+") as f:
         f.write("file")
@@ -212,11 +212,18 @@ def run_and_get_output(config, detach=False, preserve_fds=None, pid_file=None,
         config_file.write(conf)
 
     init = os.getenv("INIT") or "tests/init"
-    crun = get_crun_path()
-
-    os.makedirs(os.path.join(rootfs, "sbin"))
     shutil.copy2(init, os.path.join(rootfs, "init"))
     shutil.copy2(init, os.path.join(rootfs, "sbin", "init"))
+
+    crun = get_crun_path()
+    # If crun/krun creates these bind mount points they can't be removed for some of the tests.
+    head, tail = os.path.split(crun)
+    if tail == 'krun':
+        for i in ["opt/kontain/bin/km", "opt/kontain/runtime/libc.so"]:
+            dir, file = os.path.split(i)
+            os.makedirs(os.path.join(rootfs, dir))
+            f = open(os.path.join(rootfs, i), "w")
+            f.close()
 
     open(os.path.join(rootfs, "usr/share/zoneinfo/Europe/Rome"), "w").close()
     os.symlink("../usr/share/zoneinfo/Europe/Rome", os.path.join(rootfs, "etc/localtime"))


### PR DESCRIPTION
In getting crun to run its own tests using /opt/kontain/bin/km to run the test payload
a few problems were found and fixed.
Removed debug code.
In addition the tests_utils.py script was changed to do some krun specific setup to run
the crun tests using km.
Note: to run tests using km the environment variable OCI_RUNTIME must set to point to krun
instead of crun.  krun is normally a symbolic link to the crun program.

Tested by running make check-TESTS.