### PR TITLE
Fix check for failure returned by add_kontain_config().

### DIFF
--- a/src/create.c
+++ b/src/create.c
@@ -165,7 +165,7 @@ crun_command_create (struct crun_global_arguments *global_args, int argc, char *
 
   if (crun_context.kontain) {
     ret = add_kontain_config(container);
-    if (ret < 0) {
+    if (ret != 0) {
       libcrun_fail_with_error(0, "adding kontain bind mounts");
       return ret;
     }

--- a/src/run.c
+++ b/src/run.c
@@ -168,7 +168,7 @@ crun_command_run (struct crun_global_arguments *global_args, int argc, char **ar
 
   if (crun_context.kontain) {
     ret = add_kontain_config(container);
-    if (ret < 0) {
+    if (ret != 0) {
       libcrun_fail_with_error(0, "adding kontain bind mounts");
     }
   }


### PR DESCRIPTION
Tested by running the crun tests.  Both with and without km.