### PR TITLE
Allow some non km executables to run (by exec) in a kontain container

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -34,7 +34,9 @@ libcrun_SOURCES = src/libcrun/utils.c \
 			src/libcrun/chroot_realpath.c \
 			src/libcrun/signals.c \
 			src/libcrun/seccomp_notify.c \
-			src/libcrun/kontain.c
+			src/libcrun/kontain.c \
+			src/libcrun/kontain_nonkmexec.c \
+			src/libcrun/sha256.c
 
 
 libcrun_la_SOURCES = $(libcrun_SOURCES)

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -2504,9 +2504,21 @@ libcrun_container_exec (libcrun_context_t *context, const char *id, runtime_spec
         }
 
       if (context->kontain) {
-        int rc = libcrun_kontain_argv(&process->args, &exec_path);
+        char* new_execpath;
+        int rc = libcrun_kontain_nonkmexec_allowed(exec_path, &new_execpath);
         if (rc != 0) {
-          libcrun_fail_with_error (rc, "exec: fixup argv");
+          libcrun_fail_with_error(rc, "allow non-km executable check failed");
+        }
+        if (new_execpath == NULL) {
+          // Run as a payload
+          rc = libcrun_kontain_argv(&process->args, &exec_path);
+          if (rc != 0) {
+            libcrun_fail_with_error (rc, "exec: fixup argv");
+          }
+        } else {
+          // Run the returned path without km.
+          free((char*)exec_path);
+          exec_path = new_execpath;
         }
       }
 

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -2513,7 +2513,7 @@ libcrun_container_exec (libcrun_context_t *context, const char *id, runtime_spec
           // Run as a payload
           rc = libcrun_kontain_argv(&process->args, &exec_path);
           if (rc != 0) {
-            libcrun_fail_with_error (rc, "exec: fixup argv");
+            libcrun_fail_with_error (rc, "failed to setup %s to run in a kontain VM", exec_path);
           }
         } else {
           // Run the returned path without km.

--- a/src/libcrun/kontain.h
+++ b/src/libcrun/kontain.h
@@ -20,5 +20,7 @@
 
 #define KM_BIN_PATH "/opt/kontain/bin/km"
 int libcrun_kontain_argv(char ***argv, const char **execpath);
+int libcrun_kontain_nonkmexec_allowed(const char* execpath, char** execpath_allowed);
+void libcrun_kontain_nonkmexec_clean(void);
 
 #endif

--- a/src/libcrun/kontain_nonkmexec.c
+++ b/src/libcrun/kontain_nonkmexec.c
@@ -134,11 +134,8 @@ sha256_file(char* file, char *returned_hash)
       return errno;
    }
    sha256_final(&ctx, final_hash);
-
    close(f);
-
    hash_2_ascii(final_hash, returned_hash);
-
    return 0;
 }
 
@@ -186,9 +183,7 @@ kontain_execpath_builddb(execpath_state_t* statep)
    execpath_entry_t* tail = NULL;
    int rc = 0;
 
-   if (statep->execpath_dbpath != NULL) {
-      kontain_execpath_freedb(statep);
-   }
+   kontain_execpath_freedb(statep);
    f = fopen(statep->execpath_dbpath, "r");
    if (f == NULL) {
       libcrun_fail_with_error(errno, "Couldn't open %s", statep->execpath_dbpath);
@@ -247,6 +242,7 @@ kontain_execpath_builddb(execpath_state_t* statep)
       }
 
       // Chain entry on to the end of the list
+      libcrun_warning("Adding nonkm path: %s, %s, %s", fields[0], fields[1], fields[2]);
       if (tail == NULL) {
          SLIST_INSERT_HEAD(&statep->execpath_head, epp, link);
       } else {

--- a/src/libcrun/kontain_nonkmexec.c
+++ b/src/libcrun/kontain_nonkmexec.c
@@ -32,13 +32,12 @@
 #include "sha256.h"
 
 /*
- * What is going on in here?
- * We need to allow non kontain programs to be run inside of a kontain container.
- * But, we don't want arbitrary programs to be run.  So, we have a list of acceptable
+ * SOmetimes we need to allow programs to be run outside of kontain's vm encapsulation.
+ * But, we don't want arbitrary programs to be run this way.  So, we have a list of acceptable
  * programs that "docker exec ...." should be able to run.  This list is stored in
  * file (see KONTAIN_KRUN_CONFIG definition below).  When it is time to do the
- * exec() system call we parse the file, check to see if the program we are execing
- * too is allowed to run without km.  If it is allowed we exec the program directly.
+ * exec() system call we parse the config file, check to see if the program we are execing
+ * is allowed to run without vm encapsulation.  If it is allowed we exec the program directly.
  * If not, the program will need to run within a km virtual machine.
  * This blob of code is just used to see if a program should be allowed to run without
  * km containment.  The caller of libcrun_kontain_nonkmexec_allowed() uses the returned
@@ -165,9 +164,12 @@ split_into_fields(char* dbentry, char *fields[])
  * Entries in the file are a single line with fields separated by colons.
  * There are 3 fields:
  *   regular expression to match an input string against
- *   the file to exec to if the re matches
- *   a sha of the file being exec'ed to to verify the file is unchanged since the
+ *   the file to exec to if the regular expression matches
+ *   the sha of the file being exec'ed to to verify the file is unchanged since the
  *   db was created.
+ * Example of a line in the file:
+ *   /bin/ping|/usr/bin/ping:/bin/ping:XXXXXX
+ * Where XXXXXX is the sha256 of the file /bin/ping.
  * Failures is this function cause the process to exit.
  *
  * We should probably use some sort of json representation for this instead of the

--- a/src/libcrun/kontain_nonkmexec.c
+++ b/src/libcrun/kontain_nonkmexec.c
@@ -1,0 +1,347 @@
+/*
+ * crun - OCI runtime written in C
+ *
+ * Copyright (C) 2020 Kontain Inc.
+ * crun is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * crun is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with crun.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdio.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <string.h>
+#include <time.h>
+#include <sys/queue.h>
+#include <regex.h>
+#include <stdlib.h>
+#include <errno.h>
+#include "utils.h"
+#include "sha256.h"
+
+/*
+ * What is going on in here?
+ * We need to allow non kontain programs to be run inside of a kontain container.
+ * But, we don't want arbitrary programs to be run.  So, we have a list of acceptable
+ * programs that "docker exec ...." should be able to run.  This list is stored in
+ * file (see KONTAIN_OK_EXEC_TARGETS definition below).  When it is time to do the
+ * exec() system call we parse the file, check to see if the program we are execing
+ * too is allowed to run without km.  If it is allowed we exec the program directly.
+ * If not, the program will need to run within a km virtual machine.
+ * This blob of code is just use to see if a program should be allowed to run without
+ * km containment.  The caller of libcrun_kontain_nonkmexec_allowed() uses the returned
+ * information to form the appropriate exec arguments.
+ */
+
+struct execpath_entry {
+   SLIST_ENTRY(execpath_entry) link;
+   regex_t re;
+   char* path;
+   char sha256[SHA256_BLOCK_SIZE * 2 + 1];
+};
+typedef struct execpath_entry execpath_entry_t;
+
+SLIST_HEAD(execpath_head, execpath_entry);
+typedef struct execpath_head execpath_head_t;
+
+struct execpath_state {
+   pthread_mutex_t execpath_mutex;          // do we need this?
+   execpath_head_t execpath_head;
+   char* execpath_dbpath;                   // the path we read to populate the execpath_head
+   struct timespec execpath_mtime;          // dbpath mtime when the file was read
+};
+typedef struct execpath_state execpath_state_t;
+
+#define KONTAIN_OK_EXEC_TARGETS	"/var/lib/krun/nonkm_exec_ok_config"
+
+execpath_state_t execpath_state = {
+   PTHREAD_MUTEX_INITIALIZER,
+   SLIST_HEAD_INITIALIZER(&execpath_state.execpath_head),
+   KONTAIN_OK_EXEC_TARGETS,
+   { 0, 0 }
+};
+
+static void
+kontain_execpath_freedb(execpath_state_t* statep)
+{
+   execpath_entry_t* epp;
+
+   while (!SLIST_EMPTY(&statep->execpath_head)) {
+      epp = SLIST_FIRST(&statep->execpath_head);
+      SLIST_REMOVE_HEAD(&statep->execpath_head, link);
+      free(epp->path);
+      regfree(&epp->re);
+      free(epp);
+   }
+   memset(&statep->execpath_mtime, 0, sizeof(statep->execpath_mtime));
+}
+
+// Destroy the execpath ok db.
+void
+libcrun_kontain_nonkmexec_clean(void)
+{
+   kontain_execpath_freedb(&execpath_state);
+}
+
+static void
+hash_2_ascii(BYTE hash[SHA256_BLOCK_SIZE], char *ascii)
+{
+   int i;
+   for (i = 0; i < SHA256_BLOCK_SIZE; i++) {
+      snprintf(&ascii[i * 2], 3, "%02x", hash[i]);
+   }
+   ascii[i * 2] = 0;
+}
+
+/*
+ * Compute the sha256 hash of the passed file.
+ * Return the hash in ascii in returned_hash.
+ * Returns:
+ *   0 - success
+ *   != 0 - an errno value describing what failed
+ */
+static int
+sha256_file(char* file, char *returned_hash)
+{
+   int f;
+   unsigned char filebuf[128*1024];
+   SHA256_CTX ctx;
+   BYTE final_hash[SHA256_BLOCK_SIZE];
+   ssize_t bytesread;
+
+   f = open(file, O_RDONLY);
+   if (f < 0) {
+      return errno;
+   }
+
+   sha256_init(&ctx);
+   while ((bytesread = read(f, filebuf, sizeof(filebuf))) > 0) {
+      sha256_update(&ctx, filebuf, bytesread);
+   }
+   if (bytesread < 0) {
+      return errno;
+   }
+   sha256_final(&ctx, final_hash);
+
+   close(f);
+
+   hash_2_ascii(final_hash, returned_hash);
+
+   return 0;
+}
+
+// Split a line from the exec ok file into its fields
+static int
+split_into_fields(char* dbentry, char *fields[])
+{
+   char* saveptr = NULL;
+
+   fields[0] = strtok_r(dbentry, ":", &saveptr);
+   if (fields[0] == NULL) {
+      return EINVAL;
+   }
+   fields[1] = strtok_r(NULL, ":", &saveptr);
+   if (fields[0] == NULL) {
+      return EINVAL;
+   }
+   fields[2] = strtok_r(NULL, ":", &saveptr);
+   if (fields[2] == NULL) {
+      return EINVAL;
+   }
+   return 0;
+}
+
+/*
+ * Read a execpath database and place it into execpath_state_t pointed to by statep.
+ * Entries in the file are a single line with fields separated by colons.
+ * There are 3 fields:
+ *   regular expression to match an input string against
+ *   the file to exec to if the re matches
+ *   a sha of the file being exec'ed to to verify the file is unchanged since the
+ *   db was created.
+ * Failures is this function cause the process to exit.
+ *
+ * We should probably use some sort of json representation for this instead of the
+ * archaic colon separated fields.
+ */
+static void
+kontain_execpath_builddb(execpath_state_t* statep)
+{
+   char buf[1024];
+   FILE* f = NULL;
+   char *fields[3];
+   execpath_entry_t* epp = NULL;
+   execpath_entry_t* tail = NULL;
+   int rc = 0;
+
+   if (statep->execpath_dbpath != NULL) {
+      kontain_execpath_freedb(statep);
+   }
+   f = fopen(statep->execpath_dbpath, "r");
+   if (f == NULL) {
+      libcrun_fail_with_error(errno, "Couldn't open %s", statep->execpath_dbpath);
+   }
+   buf[sizeof(buf)-1] = 0;
+   while (fgets(buf, sizeof(buf), f) != NULL) {
+      if (buf[sizeof(buf)-1] != 0) {
+         // a really long line.
+         rc = E2BIG;
+         buf[sizeof(buf)-1] = 0;
+         libcrun_fail_with_error(rc, "execpath db line too long: %s", buf);
+      }
+      if (buf[0] == '#') {  // ignore comments
+         continue;
+      }
+      char* s = strchr(buf, '\n');
+      if (s != NULL) {
+         *s = 0;
+      }
+      // Split into fields
+      if (split_into_fields(buf, fields) != 0) {
+         rc = EINVAL;
+         libcrun_fail_with_error(rc, "Couldn't split <%s> into fields", buf);
+      }
+
+      epp = calloc(sizeof(execpath_entry_t), 1);
+      if (epp == NULL) {
+         libcrun_fail_with_error(ENOMEM, "Couldn't allocate %d bytes of memory", sizeof(execpath_entry_t));
+      }
+
+      // Compile regular expression.
+      rc = regcomp(&epp->re, fields[0], REG_EXTENDED | REG_NOSUB);
+      if (rc != 0) {
+         char regerrbuf[128];
+         regerror(rc, &epp->re, regerrbuf, sizeof(regerrbuf));
+         libcrun_fail_with_error(rc, "Couldn't compile regular expression %s, %s", fields[0], regerrbuf);
+      }
+      epp->path = strdup(fields[1]);
+      if (epp->path == NULL) {
+         rc = ENOMEM;
+         libcrun_fail_with_error(rc, "Couldn't strdup %s", fields[1]);
+      }
+
+      // Compute hash of target file
+      rc = sha256_file(fields[1], epp->sha256);
+      if (rc != 0) {
+         libcrun_fail_with_error(rc, "Couldn't compute hash of file %s", fields[1]);
+      }
+      // Does the hash match what the exec_ok file has?
+      if (strcmp(epp->sha256, fields[2]) != 0) {
+         printf("%s: Computed hash %s doesn't match expected hash %s\n",
+                fields[1],
+                epp->sha256,
+                fields[2]);
+         libcrun_fail_with_error(EILSEQ, "hash on file %s differ: expected: %s got: %s", epp->path, fields[2], epp->sha256);
+      }
+
+      // Chain entry on to the end of the list
+      if (tail == NULL) {
+         SLIST_INSERT_HEAD(&statep->execpath_head, epp, link);
+      } else {
+         SLIST_INSERT_AFTER(tail, epp, link);
+      }
+      tail = epp;
+      epp = NULL;
+   }
+   fclose(f);
+
+   // Remember the file's mod time
+   struct stat statb;
+   rc = stat(statep->execpath_dbpath, &statb);
+   if (rc == 0) {
+      statep->execpath_mtime = statb.st_mtim;
+   } else {
+      libcrun_fail_with_error(errno, "stat %s failed", statep->execpath_dbpath);
+   }
+}
+
+// Find an entry in the execpath_ok db that matches execpath.
+static int
+kontain_execpath_lookup(execpath_state_t* statep, const char* execpath, execpath_entry_t** eppp)
+{
+   int rc;
+   struct stat statb;
+
+   if (statep->execpath_dbpath == NULL) {
+      *eppp = NULL;
+      return 0;
+   }
+   if (stat(statep->execpath_dbpath, &statb) != 0) {
+      if (errno != ENOENT) {
+         libcrun_fail_with_error(errno, "can't access allowed nonkm executable list %s", statep->execpath_dbpath);
+         return errno;
+      }
+      // No allowed executable file, so no executable is allowed to run without km
+      *eppp = NULL;
+      return 0;
+   }
+   if (memcmp(&statb.st_mtim, &statep->execpath_mtime, sizeof(struct timespec)) != 0) {
+      kontain_execpath_builddb(statep);
+   }
+
+   execpath_entry_t* epp;
+   SLIST_FOREACH(epp, &statep->execpath_head, link) {
+      if (regexec(&epp->re, execpath, 0, NULL, 0) == 0) {
+         // this entry matches
+         *eppp = epp;
+         return 0;
+      }
+   }
+   *eppp = NULL;
+   return 0;
+}
+
+/*
+ * Given a full path to an executable that we want to pass to exec, verify that
+ * the path is allowed by looking up the path in a database.  Once a matching
+ * entry is found, take the path that should be used from the entry, then verify
+ * that the executable is the one we expect, and finally return that path to the
+ * caller.
+ * If the passed executable can't be run without km, return NULL.
+ */
+int
+libcrun_kontain_nonkmexec_allowed(const char* execpath, char** execpath_allowed)
+{
+   execpath_entry_t* epp;
+
+   // lookup up execpath
+   int rc = kontain_execpath_lookup(&execpath_state, execpath, &epp);
+   if (rc != 0) {
+      return rc;
+   }
+   if (epp == NULL) {
+      // no matching entry, they can't run without km.
+      *execpath_allowed = NULL;
+      return 0;
+   }
+
+   // Compute sha of associated path
+   char file_sha[2 * SHA256_BLOCK_SIZE + 1];
+   if ((rc = sha256_file(epp->path, file_sha)) != 0) {
+      libcrun_fail_with_error(rc, "Couldn't compute hash for file %s", epp->path);
+   }
+
+   // If computed sha doesn't match sha in matched entry, fail
+   if (strcmp(file_sha, epp->sha256) != 0) {
+      libcrun_fail_with_error(EACCES, "hashs differ %s - %s", file_sha, epp->sha256);
+   }
+
+   // Return matched path.
+   *execpath_allowed = strdup(epp->path);
+   if (*execpath_allowed == NULL) {
+      libcrun_fail_with_error(ENOMEM, "Couldn't strdup %s", *execpath_allowed);
+   }
+   return 0;
+}

--- a/src/libcrun/sha256.c
+++ b/src/libcrun/sha256.c
@@ -1,0 +1,159 @@
+/*********************************************************************
+* Filename:   sha256.c
+* Author:     Brad Conte (brad AT bradconte.com)
+* Copyright:
+* Disclaimer: This code is presented "as is" without any guarantees.
+* Details:    Implementation of the SHA-256 hashing algorithm.
+              SHA-256 is one of the three algorithms in the SHA2
+              specification. The others, SHA-384 and SHA-512, are not
+              offered in this implementation.
+              Algorithm specification can be found here:
+               * http://csrc.nist.gov/publications/fips/fips180-2/fips180-2withchangenotice.pdf
+              This implementation uses little endian byte order.
+*********************************************************************/
+
+/*************************** HEADER FILES ***************************/
+#include <stdlib.h>
+#include <memory.h>
+#include "sha256.h"
+
+/****************************** MACROS ******************************/
+#define ROTLEFT(a,b) (((a) << (b)) | ((a) >> (32-(b))))
+#define ROTRIGHT(a,b) (((a) >> (b)) | ((a) << (32-(b))))
+
+#define CH(x,y,z) (((x) & (y)) ^ (~(x) & (z)))
+#define MAJ(x,y,z) (((x) & (y)) ^ ((x) & (z)) ^ ((y) & (z)))
+#define EP0(x) (ROTRIGHT(x,2) ^ ROTRIGHT(x,13) ^ ROTRIGHT(x,22))
+#define EP1(x) (ROTRIGHT(x,6) ^ ROTRIGHT(x,11) ^ ROTRIGHT(x,25))
+#define SIG0(x) (ROTRIGHT(x,7) ^ ROTRIGHT(x,18) ^ ((x) >> 3))
+#define SIG1(x) (ROTRIGHT(x,17) ^ ROTRIGHT(x,19) ^ ((x) >> 10))
+
+/**************************** VARIABLES *****************************/
+static const WORD k[64] = {
+	0x428a2f98,0x71374491,0xb5c0fbcf,0xe9b5dba5,0x3956c25b,0x59f111f1,0x923f82a4,0xab1c5ed5,
+	0xd807aa98,0x12835b01,0x243185be,0x550c7dc3,0x72be5d74,0x80deb1fe,0x9bdc06a7,0xc19bf174,
+	0xe49b69c1,0xefbe4786,0x0fc19dc6,0x240ca1cc,0x2de92c6f,0x4a7484aa,0x5cb0a9dc,0x76f988da,
+	0x983e5152,0xa831c66d,0xb00327c8,0xbf597fc7,0xc6e00bf3,0xd5a79147,0x06ca6351,0x14292967,
+	0x27b70a85,0x2e1b2138,0x4d2c6dfc,0x53380d13,0x650a7354,0x766a0abb,0x81c2c92e,0x92722c85,
+	0xa2bfe8a1,0xa81a664b,0xc24b8b70,0xc76c51a3,0xd192e819,0xd6990624,0xf40e3585,0x106aa070,
+	0x19a4c116,0x1e376c08,0x2748774c,0x34b0bcb5,0x391c0cb3,0x4ed8aa4a,0x5b9cca4f,0x682e6ff3,
+	0x748f82ee,0x78a5636f,0x84c87814,0x8cc70208,0x90befffa,0xa4506ceb,0xbef9a3f7,0xc67178f2
+};
+
+/*********************** FUNCTION DEFINITIONS ***********************/
+void sha256_transform(SHA256_CTX *ctx, const BYTE data[])
+{
+	WORD a, b, c, d, e, f, g, h, i, j, t1, t2, m[64];
+
+	for (i = 0, j = 0; i < 16; ++i, j += 4)
+		m[i] = (data[j] << 24) | (data[j + 1] << 16) | (data[j + 2] << 8) | (data[j + 3]);
+	for ( ; i < 64; ++i)
+		m[i] = SIG1(m[i - 2]) + m[i - 7] + SIG0(m[i - 15]) + m[i - 16];
+
+	a = ctx->state[0];
+	b = ctx->state[1];
+	c = ctx->state[2];
+	d = ctx->state[3];
+	e = ctx->state[4];
+	f = ctx->state[5];
+	g = ctx->state[6];
+	h = ctx->state[7];
+
+	for (i = 0; i < 64; ++i) {
+		t1 = h + EP1(e) + CH(e,f,g) + k[i] + m[i];
+		t2 = EP0(a) + MAJ(a,b,c);
+		h = g;
+		g = f;
+		f = e;
+		e = d + t1;
+		d = c;
+		c = b;
+		b = a;
+		a = t1 + t2;
+	}
+
+	ctx->state[0] += a;
+	ctx->state[1] += b;
+	ctx->state[2] += c;
+	ctx->state[3] += d;
+	ctx->state[4] += e;
+	ctx->state[5] += f;
+	ctx->state[6] += g;
+	ctx->state[7] += h;
+}
+
+void sha256_init(SHA256_CTX *ctx)
+{
+	ctx->datalen = 0;
+	ctx->bitlen = 0;
+	ctx->state[0] = 0x6a09e667;
+	ctx->state[1] = 0xbb67ae85;
+	ctx->state[2] = 0x3c6ef372;
+	ctx->state[3] = 0xa54ff53a;
+	ctx->state[4] = 0x510e527f;
+	ctx->state[5] = 0x9b05688c;
+	ctx->state[6] = 0x1f83d9ab;
+	ctx->state[7] = 0x5be0cd19;
+}
+
+void sha256_update(SHA256_CTX *ctx, const BYTE data[], size_t len)
+{
+	WORD i;
+
+	for (i = 0; i < len; ++i) {
+		ctx->data[ctx->datalen] = data[i];
+		ctx->datalen++;
+		if (ctx->datalen == 64) {
+			sha256_transform(ctx, ctx->data);
+			ctx->bitlen += 512;
+			ctx->datalen = 0;
+		}
+	}
+}
+
+void sha256_final(SHA256_CTX *ctx, BYTE hash[])
+{
+	WORD i;
+
+	i = ctx->datalen;
+
+	// Pad whatever data is left in the buffer.
+	if (ctx->datalen < 56) {
+		ctx->data[i++] = 0x80;
+		while (i < 56)
+			ctx->data[i++] = 0x00;
+	}
+	else {
+		ctx->data[i++] = 0x80;
+		while (i < 64)
+			ctx->data[i++] = 0x00;
+		sha256_transform(ctx, ctx->data);
+		memset(ctx->data, 0, 56);
+	}
+
+	// Append to the padding the total message's length in bits and transform.
+	ctx->bitlen += ctx->datalen * 8;
+	ctx->data[63] = ctx->bitlen;
+	ctx->data[62] = ctx->bitlen >> 8;
+	ctx->data[61] = ctx->bitlen >> 16;
+	ctx->data[60] = ctx->bitlen >> 24;
+	ctx->data[59] = ctx->bitlen >> 32;
+	ctx->data[58] = ctx->bitlen >> 40;
+	ctx->data[57] = ctx->bitlen >> 48;
+	ctx->data[56] = ctx->bitlen >> 56;
+	sha256_transform(ctx, ctx->data);
+
+	// Since this implementation uses little endian byte ordering and SHA uses big endian,
+	// reverse all the bytes when copying the final state to the output hash.
+	for (i = 0; i < 4; ++i) {
+		hash[i]      = (ctx->state[0] >> (24 - i * 8)) & 0x000000ff;
+		hash[i + 4]  = (ctx->state[1] >> (24 - i * 8)) & 0x000000ff;
+		hash[i + 8]  = (ctx->state[2] >> (24 - i * 8)) & 0x000000ff;
+		hash[i + 12] = (ctx->state[3] >> (24 - i * 8)) & 0x000000ff;
+		hash[i + 16] = (ctx->state[4] >> (24 - i * 8)) & 0x000000ff;
+		hash[i + 20] = (ctx->state[5] >> (24 - i * 8)) & 0x000000ff;
+		hash[i + 24] = (ctx->state[6] >> (24 - i * 8)) & 0x000000ff;
+		hash[i + 28] = (ctx->state[7] >> (24 - i * 8)) & 0x000000ff;
+	}
+}
+

--- a/src/libcrun/sha256.h
+++ b/src/libcrun/sha256.h
@@ -1,0 +1,35 @@
+/*********************************************************************
+* Filename:   sha256.h
+* Author:     Brad Conte (brad AT bradconte.com)
+* Copyright:
+* Disclaimer: This code is presented "as is" without any guarantees.
+* Details:    Defines the API for the corresponding SHA1 implementation.
+*********************************************************************/
+
+#ifndef SHA256_H
+#define SHA256_H
+
+/*************************** HEADER FILES ***************************/
+#include <stddef.h>
+
+/****************************** MACROS ******************************/
+#define SHA256_BLOCK_SIZE 32            // SHA256 outputs a 32 byte digest
+
+/**************************** DATA TYPES ****************************/
+typedef unsigned char BYTE;             // 8-bit byte
+typedef unsigned int  WORD;             // 32-bit word, change to "long" for 16-bit machines
+
+typedef struct {
+	BYTE data[64];
+	WORD datalen;
+	unsigned long long bitlen;
+	WORD state[8];
+} SHA256_CTX;
+
+/*********************** FUNCTION DECLARATIONS **********************/
+void sha256_init(SHA256_CTX *ctx);
+void sha256_update(SHA256_CTX *ctx, const BYTE data[], size_t len);
+void sha256_final(SHA256_CTX *ctx, BYTE hash[]);
+
+#endif   // SHA256_H
+

--- a/tests/test_exec.py
+++ b/tests/test_exec.py
@@ -22,6 +22,8 @@ import os
 import shutil
 import sys
 from tests_utils import *
+import hashlib
+import datetime
 
 def test_exec():
     conf = base_config()
@@ -62,11 +64,71 @@ def test_exec_not_exists():
 
 def test_exec_detach_not_exists():
     return test_exec_not_exists_helper(False)
+
+NONKM_OK_CONF = "var/lib/krun/nonkm_exec_ok_config"
+
+def test_exec_non_km_payload_helper(execpath, nonkmok):
+    # only run these tests for krun
+    runtime = os.getenv("OCI_RUNTIME")
+    if os.path.basename(runtime) != "krun":
+        return 77  # skip this test if not using krun
+
+    conf = base_config()
+    conf['process']['args'] = ['/init', 'pause']
+    add_all_namespaces(conf)
+
+    # create allowed nonkm executables config file
+    nonkmok_file = "/tmp/nonkmok_config"
+    with open(nonkmok_file, "w") as c:
+        for nonkm_entry in nonkmok:
+            with open(nonkm_entry[2],"rb") as f:
+                bytes = f.read() # read entire file as bytes
+                readable_hash = hashlib.sha256(bytes).hexdigest()
+                c.write(nonkm_entry[0] + ":" + nonkm_entry[1] + ":" + readable_hash + "\n")
+
+    cid = None
+    try:
+        output, cid = run_and_get_output(conf, command='run', copy_file_in=[NONKM_OK_CONF, nonkmok_file], detach=True);
+        out = run_crun_command(["exec", cid, execpath, "echo", "foo"])
+        if "foo" not in out:
+            print(f"Didn't find foo in this output: {out}")
+            return -1
+    finally:
+        if cid is not None:
+            run_crun_command(["delete", "-f", cid])
+
+    os.unlink(nonkmok_file)
+    return 0
+
+def test_exec_non_km_payload_simple():
+    init = os.getenv("INIT") or "tests/init"
+    nonkmok = [ 
+                [ "/sbin/init", "/init", init ],              # no regular expression
+              ]
+    return test_exec_non_km_payload_helper("/sbin/init", nonkmok)
+
+def test_exec_non_km_payload_pattern():
+    init = os.getenv("INIT") or "tests/init"
+    nonkmok = [ 
+                [ "/sbin/init|/init", "/init", init ],        # with regular expression
+              ]
+    return test_exec_non_km_payload_helper("/init", nonkmok)
+
+def test_exec_non_km_payload_disallowed():
+    # The payload can't run without km but will work when run with km, so it succeeds.
+    init = os.getenv("INIT") or "tests/init"
+    nonkmok = [ 
+                [ "/init", "/init", init ],                   # no regular expression
+              ]
+    return test_exec_non_km_payload_helper("/sbin/init", nonkmok)
     
 all_tests = {
     "exec" : test_exec,
     "exec-not-exists" : test_exec_not_exists,
     "exec-detach-not-exists" : test_exec_detach_not_exists,
+    "exec-non-km-payload-simple" : test_exec_non_km_payload_simple,
+    "exec-non-km-payload-pattern" : test_exec_non_km_payload_pattern,
+    "exec-non-km-payload-disallowed" : test_exec_non_km_payload_disallowed,
 }
 
 if __name__ == "__main__":

--- a/tests/test_exec.py
+++ b/tests/test_exec.py
@@ -65,7 +65,7 @@ def test_exec_not_exists():
 def test_exec_detach_not_exists():
     return test_exec_not_exists_helper(False)
 
-NONKM_OK_CONF = "var/lib/krun/nonkm_exec_ok_config"
+NONKM_OK_CONF = "var/lib/krun/config"
 
 def test_exec_non_km_payload_helper(execpath, nonkmok):
     """

--- a/tests/test_exec.py
+++ b/tests/test_exec.py
@@ -68,16 +68,28 @@ def test_exec_detach_not_exists():
 NONKM_OK_CONF = "var/lib/krun/nonkm_exec_ok_config"
 
 def test_exec_non_km_payload_helper(execpath, nonkmok):
-    # only run these tests for krun
+    """
+    Run exec tests for krun only using a target executable that may be able to run
+    without km if it is allowed.
+    Arguments:
+    execpath - the executable to run in the running container
+    nonkmok - a list of entries that are to be placed into krun's config file describing
+        what executables are allowed to be run without km's help.
+    """
+
+    # only run these tests for krun, 77 tests the test controller this test was skipped
     runtime = os.getenv("OCI_RUNTIME")
     if os.path.basename(runtime) != "krun":
-        return 77  # skip this test if not using krun
+        return 77
 
+    # build config.json for the container
     conf = base_config()
     conf['process']['args'] = ['/init', 'pause']
     add_all_namespaces(conf)
 
     # create allowed nonkm executables config file
+    # run_and_get_output() will copy this file into the container
+    # krun will parse the file in the container
     nonkmok_file = "/tmp/nonkmok_config"
     with open(nonkmok_file, "w") as c:
         for nonkm_entry in nonkmok:
@@ -86,6 +98,8 @@ def test_exec_non_km_payload_helper(execpath, nonkmok):
                 readable_hash = hashlib.sha256(bytes).hexdigest()
                 c.write(nonkm_entry[0] + ":" + nonkm_entry[1] + ":" + readable_hash + "\n")
 
+    # Start the container we will exec into later.
+    # Then exec to a file in the container.
     cid = None
     try:
         output, cid = run_and_get_output(conf, command='run', copy_file_in=[NONKM_OK_CONF, nonkmok_file], detach=True);
@@ -93,6 +107,7 @@ def test_exec_non_km_payload_helper(execpath, nonkmok):
         if "foo" not in out:
             print(f"Didn't find foo in this output: {out}")
             return -1
+
     finally:
         if cid is not None:
             run_crun_command(["delete", "-f", cid])
@@ -101,6 +116,10 @@ def test_exec_non_km_payload_helper(execpath, nonkmok):
     return 0
 
 def test_exec_non_km_payload_simple():
+    """
+    Test that /sbin/init is allowed to exec into the running container without km.
+    This entry in the allowed non-km executable database does not contain a regular expression.
+    """
     init = os.getenv("INIT") or "tests/init"
     nonkmok = [ 
                 [ "/sbin/init", "/init", init ],              # no regular expression
@@ -108,6 +127,10 @@ def test_exec_non_km_payload_simple():
     return test_exec_non_km_payload_helper("/sbin/init", nonkmok)
 
 def test_exec_non_km_payload_pattern():
+    """
+    Test that /init can be execed to in the container without needing km.
+    This entry in the allowed non-km executable database contains a regular expression.
+    """
     init = os.getenv("INIT") or "tests/init"
     nonkmok = [ 
                 [ "/sbin/init|/init", "/init", init ],        # with regular expression
@@ -115,7 +138,10 @@ def test_exec_non_km_payload_pattern():
     return test_exec_non_km_payload_helper("/init", nonkmok)
 
 def test_exec_non_km_payload_disallowed():
-    # The payload can't run without km but will work when run with km, so it succeeds.
+    """
+    Test that /sbin/init will be execed to as a km payload because the allowed non-km executable database
+    does not allow it to run alone.
+    """
     init = os.getenv("INIT") or "tests/init"
     nonkmok = [ 
                 [ "/init", "/init", init ],                   # no regular expression

--- a/tests/tests_utils.py
+++ b/tests/tests_utils.py
@@ -190,7 +190,8 @@ def get_crun_path():
 
 def run_and_get_output(config, detach=False, preserve_fds=None, pid_file=None,
                        command='run', env=None, use_popen=False, hide_stderr=False,
-                       all_dev_null=False, id_container=None, relative_config_path="config.json"):
+                       all_dev_null=False, id_container=None, relative_config_path="config.json",
+                       copy_file_in=None):
     temp_dir = tempfile.mkdtemp(dir=get_tests_root())
     rootfs = os.path.join(temp_dir, "rootfs")
     os.makedirs(rootfs)
@@ -224,6 +225,14 @@ def run_and_get_output(config, detach=False, preserve_fds=None, pid_file=None,
             os.makedirs(os.path.join(rootfs, dir))
             f = open(os.path.join(rootfs, i), "w")
             f.close()
+
+    # Let the test add a file into the container. copy_file_in is a 2 item list,
+    # item 0 - container relative path of the file, and
+    # item 1 - the non-container path of the file to copy in.
+    if copy_file_in is not None:
+        dir, file = os.path.split(copy_file_in[0])
+        os.makedirs(os.path.join(rootfs, dir))
+        shutil.copy2(copy_file_in[1], os.path.join(rootfs, copy_file_in[0]))
 
     open(os.path.join(rootfs, "usr/share/zoneinfo/Europe/Rome"), "w").close()
     os.symlink("../usr/share/zoneinfo/Europe/Rome", os.path.join(rootfs, "etc/localtime"))


### PR DESCRIPTION
This change introduces the ability for "docker exec ..." to run permitted non-kontain executables
in a kontain container.  A file containing a list of permitted executables is added to the image.
That file is scanned to see if the exec'ed program is in the list.  If it is, the program is run without
km being involved.  If the program is not in the list, it will be run with the assistance of km.

The allowed executables file is lines consisting of 3 fields separated by colons.
The fields are:
  1 - a regular expression that the desired executable should be matched with.
  2 - the name of the program to be run for that match.
  3 - the hash for the program in field 2.
When a matching entry is found, we verify that the program in field 2 has the hash in
field 3.  It the hash matches we return the program from field 2 to the caller requesting permission to
run the passed program.  If the hash does not match, krun terminates.
If no matching entry is found, no program path is returned to the caller.

In addition 3 tests were added to the crun test_exec.py.  These tests are krun specific, they don't run
for the crun variety of the tests.