### PR TITLE
Removed 'symlink to km' traversal

### DIFF
--- a/src/libcrun/kontain.c
+++ b/src/libcrun/kontain.c
@@ -57,25 +57,8 @@ int libcrun_kontain_argv(char ***argv, const char **execpath)
       // the command does not exist?  Let the caller handle that.
       return errno;
    }
-   if ((statb.st_mode & S_IFMT) == S_IFLNK) {
-      char linkcontents[PATH_MAX];
-      while ((statb.st_mode & S_IFMT) == S_IFLNK) {
-         int rc = readlink(cmd, linkcontents, sizeof(linkcontents));
-         if (rc < 0) {
-            return errno;
-         }
-         linkcontents[rc] = 0;
-         if (strcmp(linkcontents, KM_BIN_PATH) == 0) {
-            // symlink to km, ok
-            return 0;
-         }
-         if (fstatat(AT_FDCWD, linkcontents, &statb, AT_SYMLINK_NOFOLLOW) != 0) {
-            return errno;
-         }
-         cmd = linkcontents;
-      }
-      // symlink to something other than km, stuff km in front of argv[0]
-   } else if (strcmp(cmd, KM_BIN_PATH) == 0) {
+   if (strcmp (cmd, KM_BIN_PATH) == 0)
+   {
       // The command is km, nothing more to do.
       return 0;
    }


### PR DESCRIPTION
After the latest PR (#1203, #1204) and discussions on symlink, we decided that
we need symlinks ONLY to bootstrap payloads in Linux, when we do not control executable start.
In KRUN when we fully control the start and ALWAYS add KM in front of the payload,
symlink traversal just breaks some use cases (e.g.  busybox, whihc uses symlinks for its own purposes)

So this fix removes symlink traversal support from KRUN

Tested manually on busybox runenv
We have an issue for adding KRUN-basd KM tests later

fixes https://github.com/kontainapp/km/issues/1207