### PR TITLE
Allow /sbin/docker-init to run without km.

### DIFF
--- a/src/libcrun/kontain.c
+++ b/src/libcrun/kontain.c
@@ -1,7 +1,7 @@
 /*
  * crun - OCI runtime written in C
  *
- * Copyright (C) 2020 Kontain Inc.
+ * Copyright (C) 2020-2021 Kontain Inc.
  * crun is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -57,9 +57,10 @@ int libcrun_kontain_argv(char ***argv, const char **execpath)
       // the command does not exist?  Let the caller handle that.
       return errno;
    }
-   if (strcmp (cmd, KM_BIN_PATH) == 0)
+   if (strcmp (cmd, KM_BIN_PATH) == 0 || strcmp(cmd, INIT_PATH) == 0)
    {
-      // The command is km, nothing more to do.
+      // The command is km or docker-init, nothing more to do.
+      // docker-init runs when you supply --init on the docker or podman run command line.
       return 0;
    }
 

--- a/src/libcrun/kontain.h
+++ b/src/libcrun/kontain.h
@@ -1,7 +1,7 @@
 /*
  * crun - OCI runtime written in C
  *
- * Copyright (C) 2020 Kontain Inc.
+ * Copyright (C) 2020-2021 Kontain Inc.
  * crun is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -19,6 +19,7 @@
 #define KONTAIN_H
 
 #define KM_BIN_PATH "/opt/kontain/bin/km"
+#define INIT_PATH "/sbin/docker-init"
 int libcrun_kontain_argv(char ***argv, const char **execpath);
 int libcrun_kontain_nonkmexec_allowed(const char* execpath, char** execpath_allowed);
 void libcrun_kontain_nonkmexec_clean(void);


### PR DESCRIPTION
When a container is started with the --init flag, the first process in the container will
be /sbin/docker-init.  kontain does not supply or build this executable.  Currently krun
tries to run docker-init as a km payload which currently has some problems.  An expedient
solution is to have km allow docker-init run without km.  This change causes krun to run
docker-init without krun.  I'm not sure if this is the correct thing to do but it helps
get beyond this problem so we can test other things.

Tested by running:
docker run -it --init  --runtime krun  kontainapp/runenv-busybox /bin/sh