### PR TITLE
Fix additional rebase problems and get crun github test workflow working.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
 
       - run: sudo apt-get update
 
-      - run: sudo apt-get install -y make git gcc build-essential pkgconf libtool libsystemd-dev libcap-dev libseccomp-dev libyajl-dev go-md2man libtool autoconf python3 automake
+      - run: sudo apt-get install -y make git gcc build-essential pkgconf libtool libsystemd-dev libcap-dev libseccomp-dev libyajl-dev go-md2man libtool autoconf python3 automake libssl-dev
 
       - run: |
           set -ex

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,7 +34,7 @@ jobs:
 
           install: |
             apt-get update -q -y
-            apt-get install -q -y automake libtool autotools-dev libseccomp-dev git make libcap-dev cmake pkg-config gcc wget go-md2man libsystemd-dev gperf clang-format libyajl-dev
+            apt-get install -q -y automake libtool autotools-dev libseccomp-dev git make libcap-dev cmake pkg-config gcc wget go-md2man libsystemd-dev gperf clang-format libyajl-dev libssl-dev
 
           run: |
             ./autogen.sh
@@ -73,7 +73,7 @@ jobs:
         sudo add-apt-repository -y ppa:criu/ppa
         sudo apt-get update -q -y
 
-        sudo apt-get install -q -y criu automake libtool autotools-dev libseccomp-dev git make libcap-dev cmake pkg-config gcc wget go-md2man libsystemd-dev gperf clang-format libyajl-dev docker.io containerd runc libasan6
+        sudo apt-get install -q -y criu automake libtool autotools-dev libseccomp-dev git make libcap-dev cmake pkg-config gcc wget go-md2man libsystemd-dev gperf clang-format libyajl-dev docker.io containerd runc libasan6 libssl-dev
 
         sudo systemctl unmask docker
         sudo systemctl start docker

--- a/.gitignore
+++ b/.gitignore
@@ -64,7 +64,6 @@ stamp-h
 stamp-h.in
 stamp-h1
 tests/init
-<<<<<<< HEAD
 tests/tests_*
 tests/*.log
 tests/*.trs

--- a/configure.ac
+++ b/configure.ac
@@ -25,6 +25,7 @@ AC_PATH_PROG(MD2MAN, go-md2man)
 AM_CONDITIONAL([HAVE_MD2MAN], [test "x$ac_cv_path_MD2MAN" != x])
 
 AC_CHECK_HEADERS([error.h linux/openat2.h])
+AC_CHECK_HEADER([bsd/queue.h], [AC_DEFINE([HAVE_BSD_QUEUE], 1, [Define if bsd/queue.h is available])])
 
 AC_CHECK_FUNCS(copy_file_range fgetxattr statx fgetpwent_r issetugid)
 
@@ -130,6 +131,10 @@ AS_IF([test "x$enable_criu" != "xno"], [
 	    ])
 ], [AC_MSG_NOTICE([CRIU support disabled per user request])])
 
+AC_SEARCH_LIBS([CRYPTO_new_ex_data], [crypto], [], [AC_MSG_ERROR([crypto library not found])])
+
+AC_SEARCH_LIBS([OPENSSL_init_ssl], [ssl], [], [AC_MSG_ERROR([ssl library not found])])
+
 FOUND_LIBS=$LIBS
 LIBS=""
 
@@ -167,10 +172,6 @@ if test -z "$GPERF"; then
 fi
 
 AC_SEARCH_LIBS([argp_parse], [argp], [], [AC_MSG_ERROR([*** argp functions not found - install libargp or argp_standalone])])
-
-AC_SEARCH_LIBS([CRYPTO_new_ex_data], [crypto], [], [AC_MSG_ERROR([crypto library not found])])
-
-AC_SEARCH_LIBS([OPENSSL_init_ssl], [ssl], [], [AC_MSG_ERROR([ssl library not found])])
 
 AM_CONDITIONAL([PYTHON_BINDINGS], [test "x$with_python_bindings" = "xyes"])
 AM_CONDITIONAL([CRIU_SUPPORT], [test "x$have_criu" = "xyes"])

--- a/src/create.c
+++ b/src/create.c
@@ -165,13 +165,15 @@ crun_command_create (struct crun_global_arguments *global_args, int argc, char *
   if (container == NULL)
     libcrun_fail_with_error (0, "error loading config.json");
 
-  if (crun_context.kontain) {
-    ret = add_kontain_config(container);
-    if (ret != 0) {
-      libcrun_fail_with_error(0, "adding kontain bind mounts");
-      return ret;
+  if (crun_context.kontain)
+    {
+      ret = add_kontain_config (container);
+      if (ret != 0)
+        {
+          libcrun_fail_with_error (0, "adding kontain bind mounts");
+          return ret;
+        }
     }
-  }
 
   crun_context.bundle = bundle;
   if (getenv ("LISTEN_FDS"))

--- a/src/crun.c
+++ b/src/crun.c
@@ -302,15 +302,19 @@ main (int argc, char **argv)
   libcrun_error_t err = NULL;
   int ret, first_argument = 0;
 
-  char *cmd = strrchr(argv[0], '/');
-  if (cmd == NULL) {
-    cmd = argv[0];
-  } else {
-    cmd++;
-  }
-  if (strcmp(cmd, "krun") == 0) {
-     arguments.kontain = true;
-  }
+  char *cmd = strrchr (argv[0], '/');
+  if (cmd == NULL)
+    {
+      cmd = argv[0];
+    }
+  else
+    {
+      cmd++;
+    }
+  if (strcmp (cmd, "krun") == 0)
+    {
+      arguments.kontain = true;
+    }
 
   argp_program_version_hook = print_version;
 

--- a/src/debug.c
+++ b/src/debug.c
@@ -8,7 +8,9 @@
 #include <unistd.h>
 #include <errno.h>
 #include <stdarg.h>
+#include <inttypes.h>
 #include <sys/sysmacros.h>
+#include <sys/param.h>
 
 #include "crun.h"
 #include "libcrun/container.h"
@@ -18,142 +20,151 @@
 FILE *tracefile;
 
 void
-debug_open_tracefile(void)
+debug_open_tracefile (void)
 {
-   if (tracefile == NULL) {
-      tracefile = fopen(TRACE_FILE, "a");
-      if (tracefile == NULL) {
-         abort();
-      }
-   }
-}
-
-void debug(char *fmt, ...)
-{
-   va_list ap;
-
-   debug_open_tracefile();
-   va_start(ap, fmt);
-   vfprintf(tracefile, fmt, ap);
-   va_end(ap);
+  if (tracefile == NULL)
+    {
+      tracefile = fopen (TRACE_FILE, "a");
+      if (tracefile == NULL)
+        {
+          abort ();
+        }
+    }
 }
 
 void
-dumpmounts(libcrun_container_t *container)
+debug (char *fmt, ...)
 {
-   runtime_spec_schema_config_schema *container_def = container->container_def;
-   int i;
+  va_list ap;
 
-   debug_open_tracefile();
-
-   for (i = 0; i < container_def->mounts_len; i++) {
-      fprintf(tracefile, "mount[%d]: source %s, destination %s, type %s, options_len %lu\n",
-         i, container_def->mounts[i]->source, container_def->mounts[i]->destination,
-         container_def->mounts[i]->type, container_def->mounts[i]->options_len);
-      for (int j = 0; j < container_def->mounts[i]->options_len; j++) {
-         fprintf(tracefile, "options[%d]: %s\n", j, container_def->mounts[i]->options[j]);
-      }
-   }
-   fflush(tracefile);
+  debug_open_tracefile ();
+  va_start (ap, fmt);
+  vfprintf (tracefile, fmt, ap);
+  va_end (ap);
 }
 
 void
-dumpdevices(libcrun_container_t *container)
+dumpmounts (libcrun_container_t *container)
 {
-   runtime_spec_schema_config_schema *container_def = container->container_def;
+  runtime_spec_schema_config_schema *container_def = container->container_def;
+  size_t i;
 
-   debug_open_tracefile();
+  debug_open_tracefile ();
 
-   for (int i = 0; i < container_def->linux->devices_len; i++) {
-      fprintf(tracefile, "devices[%d]: type %s, path %s, "
-                     "file_mode 0%o, file_mode_present %u, "
-                     "major %ld, major_present %u, "
-                     "minor %ld, minor_present %u, "
-                     "uid %u, uid_present %u, "
-                     "gid %u, gid_present %u\n",
-         i,
-         container_def->linux->devices[i]->type,
-         container_def->linux->devices[i]->path,
-         container_def->linux->devices[i]->file_mode,
-         container_def->linux->devices[i]->file_mode_present,
-         container_def->linux->devices[i]->major,
-         container_def->linux->devices[i]->major_present,
-         container_def->linux->devices[i]->minor,
-         container_def->linux->devices[i]->minor_present,
-         container_def->linux->devices[i]->uid,
-         container_def->linux->devices[i]->uid_present,
-         container_def->linux->devices[i]->gid,
-         container_def->linux->devices[i]->gid_present);
-   }
-   fflush(tracefile);
+  for (i = 0; i < container_def->mounts_len; i++)
+    {
+      fprintf (tracefile, "mount[%zu]: source %s, destination %s, type %s, options_len %zu\n",
+               i, container_def->mounts[i]->source, container_def->mounts[i]->destination,
+               container_def->mounts[i]->type, container_def->mounts[i]->options_len);
+      for (size_t j = 0; j < container_def->mounts[i]->options_len; j++)
+        {
+          fprintf (tracefile, "options[%zu]: %s\n", j, container_def->mounts[i]->options[j]);
+        }
+    }
+  fflush (tracefile);
 }
 
 void
-dumpannotations(libcrun_container_t *container)
+dumpdevices (libcrun_container_t *container)
 {
   runtime_spec_schema_config_schema *container_def = container->container_def;
 
-  debug_open_tracefile();
+  debug_open_tracefile ();
 
-  fprintf(tracefile, "Begin annotations\n");
-  if (container_def->annotations != NULL) {
-    for (int i = 0; i < container_def->annotations->len; i++) {
-      fprintf(tracefile, "%s = %s\n", container_def->annotations->keys[i], container_def->annotations->values[i]);
+  for (size_t i = 0; i < container_def->linux->devices_len; i++)
+    {
+      fprintf (tracefile, "devices[%zu]: type %s, path %s, "
+                          "file_mode 0%o, file_mode_present %u, "
+                          "major %" PRIu64 ", major_present %u, "
+                          "minor %" PRIu64 ", minor_present %u, "
+                          "uid %u, uid_present %u, "
+                          "gid %u, gid_present %u\n",
+               i,
+               container_def->linux->devices[i]->type,
+               container_def->linux->devices[i]->path,
+               container_def->linux->devices[i]->file_mode,
+               container_def->linux->devices[i]->file_mode_present,
+               container_def->linux->devices[i]->major,
+               container_def->linux->devices[i]->major_present,
+               container_def->linux->devices[i]->minor,
+               container_def->linux->devices[i]->minor_present,
+               container_def->linux->devices[i]->uid,
+               container_def->linux->devices[i]->uid_present,
+               container_def->linux->devices[i]->gid,
+               container_def->linux->devices[i]->gid_present);
     }
-  }
-  fprintf(tracefile, "End annotations\n");
-
-  fflush(tracefile);
+  fflush (tracefile);
 }
 
 void
-dumpconfig(const char *config_file)
+dumpannotations (libcrun_container_t *container)
+{
+  runtime_spec_schema_config_schema *container_def = container->container_def;
+
+  debug_open_tracefile ();
+
+  fprintf (tracefile, "Begin annotations\n");
+  if (container_def->annotations != NULL)
+    {
+      for (size_t i = 0; i < container_def->annotations->len; i++)
+        {
+          fprintf (tracefile, "%s = %s\n", container_def->annotations->keys[i], container_def->annotations->values[i]);
+        }
+    }
+  fprintf (tracefile, "End annotations\n");
+
+  fflush (tracefile);
+}
+
+void
+dumpconfig (const char *config_file)
 {
   FILE *config;
-  char buffer[16*1024];
+  char buffer[16 * 1024];
 
-  config = fopen(config_file, "r");
-  debug_open_tracefile();
+  config = fopen (config_file, "r");
+  debug_open_tracefile ();
 
-  fprintf(tracefile, "Begin %s\n", config_file);
-  while (fgets(buffer, sizeof(buffer), config) != NULL) {
-    fputs(buffer, tracefile);
-  }
-  fprintf(tracefile, "\nEnd %s\n", config_file);
+  fprintf (tracefile, "Begin %s\n", config_file);
+  while (fgets (buffer, sizeof (buffer), config) != NULL)
+    {
+      fputs (buffer, tracefile);
+    }
+  fprintf (tracefile, "\nEnd %s\n", config_file);
 
-  fclose(config);
-  fflush(tracefile);
+  fclose (config);
+  fflush (tracefile);
 }
 
-
 void
-runtime_spec_to_file(runtime_spec_schema_config_schema *container)
+runtime_spec_to_file (runtime_spec_schema_config_schema *container)
 {
   parser_error err;
   char *json_buf = NULL;
 
-  json_buf = runtime_spec_schema_config_schema_generate_json(container, 0, &err);
-  if (json_buf == NULL) {
-    libcrun_fail_with_error(0, err);
-    return;
-  }
+  json_buf = runtime_spec_schema_config_schema_generate_json (container, 0, &err);
+  if (json_buf == NULL)
+    {
+      libcrun_fail_with_error (0, err);
+      return;
+    }
 
-  debug_open_tracefile();
+  debug_open_tracefile ();
 
-  fputs(json_buf, tracefile);
+  fputs (json_buf, tracefile);
 
-  free(json_buf);
+  free (json_buf);
 }
 
 void
-dump_crun_context(libcrun_context_t *context)
+dump_crun_context (libcrun_context_t *context)
 {
   char cwd[PATH_MAX];
 
-  debug_open_tracefile();
-  getcwd(cwd, sizeof(cwd));
-  fprintf(tracefile, "cwd %s\n", cwd);
-  fprintf(tracefile, "state_root %s, id %s, bundle %s, config_file %s, pid_file %s, notify_socket %s\n",
-    context->state_root, context->id, context->bundle, context->config_file, context->pid_file, context->notify_socket);
-  fflush(tracefile);
+  debug_open_tracefile ();
+  getcwd (cwd, sizeof (cwd));
+  fprintf (tracefile, "cwd %s\n", cwd);
+  fprintf (tracefile, "state_root %s, id %s, bundle %s, config_file %s, pid_file %s, notify_socket %s\n",
+           context->state_root, context->id, context->bundle, context->config_file, context->pid_file, context->notify_socket);
+  fflush (tracefile);
 }

--- a/src/debug.h
+++ b/src/debug.h
@@ -20,12 +20,12 @@
 
 #include "crun.h"
 
-void dumpmounts(libcrun_container_t *container);
-void dumpdevices(libcrun_container_t *container);
-void dumpannotations(libcrun_container_t *container);
-void dumpconfig(const char *config_file);
-void runtime_spec_to_file(runtime_spec_schema_config_schema *container);
-void dump_crun_context(libcrun_context_t *context);
-void debug(char *fmt, ...);
+void dumpmounts (libcrun_container_t *container);
+void dumpdevices (libcrun_container_t *container);
+void dumpannotations (libcrun_container_t *container);
+void dumpconfig (const char *config_file);
+void runtime_spec_to_file (runtime_spec_schema_config_schema *container);
+void dump_crun_context (libcrun_context_t *context);
+void debug (char *fmt, ...);
 
 #endif

--- a/src/kontain.c
+++ b/src/kontain.c
@@ -34,24 +34,25 @@
 #include "libcrun/utils.h"
 
 static runtime_spec_schema_defs_mount *
-build_kontain_bind_mount(char *src, char *dst)
+build_kontain_bind_mount (char *src, char *dst)
 {
-  runtime_spec_schema_defs_mount *m = calloc(1, sizeof(runtime_spec_schema_defs_mount));
-  if (m != NULL) {
-    m->source = strdup(src);
-    m->destination = strdup(dst);
+  runtime_spec_schema_defs_mount *m = calloc (1, sizeof (runtime_spec_schema_defs_mount));
+  if (m != NULL)
+    {
+      m->source = strdup (src);
+      m->destination = strdup (dst);
 #define BIND_MOUNT_OPTIONS_COUNT 2
-    m->options = calloc(BIND_MOUNT_OPTIONS_COUNT, sizeof(char *));
-    m->options[0] = strdup("rbind");
-    m->options[1] = strdup("rprivate");
-    m->options_len = BIND_MOUNT_OPTIONS_COUNT;
-    m->type = strdup("bind");
-  }
+      m->options = calloc (BIND_MOUNT_OPTIONS_COUNT, sizeof (char *));
+      m->options[0] = strdup ("rbind");
+      m->options[1] = strdup ("rprivate");
+      m->options_len = BIND_MOUNT_OPTIONS_COUNT;
+      m->type = strdup ("bind");
+    }
   return m;
 }
 
 int
-add_kontain_bind_mounts(libcrun_container_t *container, const char *privileged)
+add_kontain_bind_mounts (libcrun_container_t *container, const char *privileged)
 {
   runtime_spec_schema_config_schema *container_def = container->container_def;
   runtime_spec_schema_defs_mount **mounts = container_def->mounts;
@@ -60,114 +61,126 @@ add_kontain_bind_mounts(libcrun_container_t *container, const char *privileged)
   int need_kkm = 0;
 
   // for unprivileged podman we bind mount /dev/kvm or /dev/kkm
-  if (privileged != NULL && strcasecmp(privileged, "false") == 0) {
-    struct stat statb;
-    if (stat("/dev/kvm", &statb) == 0) {
-      need_kvm = 1;
+  if (privileged != NULL && strcasecmp (privileged, "false") == 0)
+    {
+      struct stat statb;
+      if (stat ("/dev/kvm", &statb) == 0)
+        {
+          need_kvm = 1;
+        }
+      if (stat ("/dev/kkm", &statb) == 0)
+        {
+          need_kkm = 1;
+        }
     }
-    if (stat("/dev/kkm", &statb) == 0) {
-      need_kkm = 1;
-    }
-  }
 
   int offset = 0;
   int new_mounts_len = mounts_len + 1 + need_kvm + need_kkm;
-  runtime_spec_schema_defs_mount **new_mounts = realloc(mounts, new_mounts_len * sizeof(runtime_spec_schema_defs_mount *));
-  if (new_mounts == NULL) {
-    return ENOMEM;
-  }
+  runtime_spec_schema_defs_mount **new_mounts = realloc (mounts, new_mounts_len * sizeof (runtime_spec_schema_defs_mount *));
+  if (new_mounts == NULL)
+    {
+      return ENOMEM;
+    }
   container_def->mounts = new_mounts;
-  container_def->mounts[mounts_len] = build_kontain_bind_mount("/opt/kontain/bin/km", "/opt/kontain/bin/km");
+  container_def->mounts[mounts_len] = build_kontain_bind_mount ("/opt/kontain/bin/km", "/opt/kontain/bin/km");
   if (container_def->mounts[mounts_len + offset] == NULL)
     return ENOMEM;
   offset++;
 
-  if (need_kvm != 0) {
-    container_def->mounts[mounts_len + offset] = build_kontain_bind_mount("/dev/kvm", "/dev/kvm");
-    if (container_def->mounts[mounts_len + offset] == NULL)
-      return ENOMEM;
-    offset++;
-  }
-  if (need_kkm != 0) {
-    container_def->mounts[mounts_len + offset] = build_kontain_bind_mount("/dev/kkm", "/dev/kkm");
-    if (container_def->mounts[mounts_len + offset] == NULL)
-      return ENOMEM;
-    offset++;
-  }
+  if (need_kvm != 0)
+    {
+      container_def->mounts[mounts_len + offset] = build_kontain_bind_mount ("/dev/kvm", "/dev/kvm");
+      if (container_def->mounts[mounts_len + offset] == NULL)
+        return ENOMEM;
+      offset++;
+    }
+  if (need_kkm != 0)
+    {
+      container_def->mounts[mounts_len + offset] = build_kontain_bind_mount ("/dev/kkm", "/dev/kkm");
+      if (container_def->mounts[mounts_len + offset] == NULL)
+        return ENOMEM;
+      offset++;
+    }
   container_def->mounts_len = new_mounts_len;
 
   return 0;
 }
 
 int
-build_kontain_device(const char *devpath,
-   runtime_spec_schema_defs_linux_device **devp,
-   runtime_spec_schema_defs_linux_device_cgroup **accessp)
+build_kontain_device (const char *devpath,
+                      runtime_spec_schema_defs_linux_device **devp,
+                      runtime_spec_schema_defs_linux_device_cgroup **accessp)
 {
   struct stat statb;
   runtime_spec_schema_defs_linux_device *dev = NULL;
   runtime_spec_schema_defs_linux_device_cgroup *access = NULL;
   int ret = 0;
 
-  if (stat(devpath, &statb) == 0) {
-    dev = calloc(1, sizeof(runtime_spec_schema_defs_linux_device));
-    if (dev == NULL) {
-      return ENOMEM;
-    }
-    access = calloc(1, sizeof(runtime_spec_schema_defs_linux_device_cgroup));
-    if (access == NULL) {
-      return ENOMEM;
-    }
+  if (stat (devpath, &statb) == 0)
+    {
+      dev = calloc (1, sizeof (runtime_spec_schema_defs_linux_device));
+      if (dev == NULL)
+        {
+          return ENOMEM;
+        }
+      access = calloc (1, sizeof (runtime_spec_schema_defs_linux_device_cgroup));
+      if (access == NULL)
+        {
+          return ENOMEM;
+        }
 
-    // Build the device
-    switch (statb.st_mode & S_IFMT) {
-    case S_IFBLK:
-      dev->type = strdup("b");
-      break;
-    case S_IFCHR:
-      dev->type = strdup("c");
-      break;
-    case S_IFIFO:
-      dev->type = strdup("p");
-      break;
-    default:
-      free(dev);
-      free(access);
-      return EINVAL;
-      break;
+      // Build the device
+      switch (statb.st_mode & S_IFMT)
+        {
+        case S_IFBLK:
+          dev->type = strdup ("b");
+          break;
+        case S_IFCHR:
+          dev->type = strdup ("c");
+          break;
+        case S_IFIFO:
+          dev->type = strdup ("p");
+          break;
+        default:
+          free (dev);
+          free (access);
+          return EINVAL;
+          break;
+        }
+      dev->path = strdup (devpath);
+      dev->file_mode_present = 1;
+      dev->file_mode = statb.st_mode;
+      dev->major_present = 1;
+      dev->major = major (statb.st_rdev);
+      dev->minor_present = 1;
+      dev->minor = minor (statb.st_rdev);
+      dev->uid_present = 1;
+      dev->uid = statb.st_uid;
+      dev->gid_present = 1;
+      dev->gid = statb.st_gid;
+
+      // Build the granted access
+      access->allow = 1;
+      access->allow_present = 1;
+      access->type = strdup (dev->type);
+      access->major = dev->major;
+      access->major_present = 1;
+      access->minor = dev->minor;
+      access->minor_present = 1;
+      access->access = strdup ("rwm");
+
+      *devp = dev;
+      *accessp = access;
     }
-    dev->path = strdup(devpath);
-    dev->file_mode_present = 1;
-    dev->file_mode = statb.st_mode;
-    dev->major_present = 1;
-    dev->major = major(statb.st_rdev);
-    dev->minor_present = 1;
-    dev->minor = minor(statb.st_rdev);
-    dev->uid_present  = 1;
-    dev->uid = statb.st_uid;
-    dev->gid_present = 1;
-    dev->gid = statb.st_gid;
-
-     // Build the granted access
-     access->allow = 1;
-     access->allow_present = 1;
-     access->type = strdup(dev->type);
-     access->major = dev->major;
-     access->major_present = 1;
-     access->minor = dev->minor;
-     access->minor_present = 1;
-     access->access = strdup("rwm");
-
-     *devp = dev;
-     *accessp = access;
-  } else {
-    ret = errno;
-  }
+  else
+    {
+      ret = errno;
+    }
   return ret;
 }
 
 int
-add_kontain_device(libcrun_container_t *container, const char *device)
+add_kontain_device (libcrun_container_t *container, const char *device)
 {
   runtime_spec_schema_config_schema *container_def = container->container_def;
   runtime_spec_schema_config_linux *linux = container_def->linux;
@@ -175,35 +188,40 @@ add_kontain_device(libcrun_container_t *container, const char *device)
   runtime_spec_schema_defs_linux_device_cgroup *access;
   int ret = ENODEV;
 
-  ret = build_kontain_device(device, &dev, &access);
-  if (ret != 0) {
-    return ret;
-  }
+  ret = build_kontain_device (device, &dev, &access);
+  if (ret != 0)
+    {
+      return ret;
+    }
 
   // No resources, make an empty one of those first
-  if (linux->resources == NULL) {
-    linux->resources = calloc(1, sizeof(*linux->resources));
-    if (linux->resources == NULL) {
-      return ENOMEM;
+  if (linux->resources == NULL)
+    {
+      linux->resources = calloc (1, sizeof (*linux->resources));
+      if (linux->resources == NULL)
+        {
+          return ENOMEM;
+        }
     }
-  }
 
   // Grow devices array
   size_t new_devices_len = linux->devices_len + 1;
-  runtime_spec_schema_defs_linux_device **new_devices = realloc(linux->devices, new_devices_len * sizeof(runtime_spec_schema_defs_linux_device **));
-  if (new_devices == NULL) {
-    return ENOMEM;
-  }
+  runtime_spec_schema_defs_linux_device **new_devices = realloc (linux->devices, new_devices_len * sizeof (runtime_spec_schema_defs_linux_device **));
+  if (new_devices == NULL)
+    {
+      return ENOMEM;
+    }
   new_devices[linux->devices_len] = dev;
   linux->devices = new_devices;
   linux->devices_len = new_devices_len;
 
   // Grow access array
   size_t new_res_devices_len = linux->resources->devices_len + 1;
-  runtime_spec_schema_defs_linux_device_cgroup **new_res_devices = realloc(linux->resources->devices, new_res_devices_len * sizeof(runtime_spec_schema_defs_linux_device_cgroup));
-  if (new_res_devices == NULL) {
-    return ENOMEM;
-  }
+  runtime_spec_schema_defs_linux_device_cgroup **new_res_devices = realloc (linux->resources->devices, new_res_devices_len * sizeof (runtime_spec_schema_defs_linux_device_cgroup));
+  if (new_res_devices == NULL)
+    {
+      return ENOMEM;
+    }
   new_res_devices[linux->resources->devices_len] = access;
   linux->resources->devices = new_res_devices;
   linux->resources->devices_len = new_res_devices_len;
@@ -212,38 +230,42 @@ add_kontain_device(libcrun_container_t *container, const char *device)
 }
 
 int
-add_kontain_devices(libcrun_container_t *container)
+add_kontain_devices (libcrun_container_t *container)
 {
   int ret = 0;
   struct stat statb;
 
-  if (stat("/dev/kvm", &statb) == 0) {
-    ret = add_kontain_device(container, "/dev/kvm");
-    if (ret != 0)
-      return ret;
-  }
-  if (stat("/dev/kkm", &statb) == 0) {
-    ret = add_kontain_device(container, "/dev/kkm");
-    if (ret != 0)
-      return ret;
-  }
+  if (stat ("/dev/kvm", &statb) == 0)
+    {
+      ret = add_kontain_device (container, "/dev/kvm");
+      if (ret != 0)
+        return ret;
+    }
+  if (stat ("/dev/kkm", &statb) == 0)
+    {
+      ret = add_kontain_device (container, "/dev/kkm");
+      if (ret != 0)
+        return ret;
+    }
   return 0;
 }
 
 int
-add_kontain_config(libcrun_container_t *container)
+add_kontain_config (libcrun_container_t *container)
 {
   int ret;
-  const char *privileged = find_annotation(container, "io.podman.annotations.privileged");
+  const char *privileged = find_annotation (container, "io.podman.annotations.privileged");
 
-  ret = add_kontain_bind_mounts(container, privileged);
-  if (ret != 0) {
-    return ret;
-  }
+  ret = add_kontain_bind_mounts (container, privileged);
+  if (ret != 0)
+    {
+      return ret;
+    }
 
   // For docker or privileged podman, we create the /dev/kvm and/or kkm device.
-  if (privileged == NULL || strcasecmp(privileged, "true") == 0) {
-    ret = add_kontain_devices(container);
-  }
+  if (privileged == NULL || strcasecmp (privileged, "true") == 0)
+    {
+      ret = add_kontain_devices (container);
+    }
   return ret;
 }

--- a/src/kontain.h
+++ b/src/kontain.h
@@ -21,6 +21,6 @@
 #include "crun.h"
 
 #define APP_KONTAIN_USEVIRT "app.kontain.use-virt"
-int add_kontain_config(libcrun_container_t *container);
+int add_kontain_config (libcrun_container_t *container);
 
 #endif

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -1192,12 +1192,14 @@ container_init_setup (void *args, pid_t own_pid, char *notify_socket, int sync_s
 
           return crun_make_error (err, errno, "open executable");
         }
-      if (entrypoint_args->context->kontain) {
-        int rc = libcrun_kontain_argv(&def->process->args, exec_path);
-        if (rc != 0) {
-          return crun_make_error (err, rc, "init: fixup argv");
+      if (entrypoint_args->context->kontain)
+        {
+          int rc = libcrun_kontain_argv (&def->process->args, exec_path);
+          if (rc != 0)
+            {
+              return crun_make_error (err, rc, "init: fixup argv");
+            }
         }
-      }
     }
 
   ret = setsid ();
@@ -3185,24 +3187,31 @@ libcrun_container_exec (libcrun_context_t *context, const char *id, runtime_spec
           libcrun_fail_with_error ((*err)->status, "%s", (*err)->msg);
         }
 
-      if (context->kontain) {
-        char* new_execpath;
-        int rc = libcrun_kontain_nonkmexec_allowed(exec_path, &new_execpath);
-        if (rc != 0) {
-          libcrun_fail_with_error(rc, "allow non-km executable check failed");
+      if (context->kontain)
+        {
+          char *new_execpath;
+          int rc = libcrun_kontain_nonkmexec_allowed (exec_path, &new_execpath);
+          if (rc != 0)
+            {
+              libcrun_fail_with_error (rc, "allow non-km executable check failed");
+            }
+          if (new_execpath == NULL)
+            {
+              // Run as a payload
+              rc = libcrun_kontain_argv (&process->args, &exec_path);
+              if (rc != 0)
+                {
+                  libcrun_fail_with_error (rc, "failed to setup %s to run in a kontain VM", exec_path);
+                }
+            }
+          else
+            {
+              // Run the returned path without km.
+              char *avoid_maintmk_warning = (char *) exec_path;
+              free (avoid_maintmk_warning);
+              exec_path = new_execpath;
+            }
         }
-        if (new_execpath == NULL) {
-          // Run as a payload
-          rc = libcrun_kontain_argv(&process->args, &exec_path);
-          if (rc != 0) {
-            libcrun_fail_with_error (rc, "failed to setup %s to run in a kontain VM", exec_path);
-          }
-        } else {
-          // Run the returned path without km.
-          free((char*)exec_path);
-          exec_path = new_execpath;
-        }
-      }
 
       if (container->container_def->linux && container->container_def->linux->personality)
         {

--- a/src/libcrun/kontain.h
+++ b/src/libcrun/kontain.h
@@ -21,8 +21,8 @@
 #define KM_BIN_PATH "/opt/kontain/bin/km"
 #define DOCKER_INIT_PATH "/sbin/docker-init"
 #define PODMAN_INIT_PATH "/dev/init"
-int libcrun_kontain_argv(char ***argv, const char **execpath);
-int libcrun_kontain_nonkmexec_allowed(const char* execpath, char** execpath_allowed);
-void libcrun_kontain_nonkmexec_clean(void);
+int libcrun_kontain_argv (char ***argv, const char **execpath);
+int libcrun_kontain_nonkmexec_allowed (const char *execpath, char **execpath_allowed);
+void libcrun_kontain_nonkmexec_clean (void);
 
 #endif

--- a/src/libcrun/kontain_nonkmexec.c
+++ b/src/libcrun/kontain_nonkmexec.c
@@ -16,6 +16,7 @@
  * along with crun.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
 #include <stdio.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -24,7 +25,11 @@
 #include <pthread.h>
 #include <string.h>
 #include <time.h>
-#include <sys/queue.h>
+#ifdef HAVE_BSD_QUEUE
+#  include <bsd/sys/queue.h>
+#else
+#  include <sys/queue.h>
+#endif
 #include <regex.h>
 #include <stdlib.h>
 #include <errno.h>
@@ -46,7 +51,8 @@
 
 struct execpath_entry
 {
-  SLIST_ENTRY (execpath_entry) link;
+  SLIST_ENTRY (execpath_entry)
+  link;
   regex_t re;
   char *path;
   char sha256[EVP_MAX_MD_SIZE * 2 + 1];
@@ -97,7 +103,7 @@ libcrun_kontain_nonkmexec_clean (void)
 static void
 hash_2_ascii (unsigned char hash[EVP_MAX_MD_SIZE], unsigned int hash_len, char *ascii)
 {
-  int i;
+  unsigned int i;
   for (i = 0; i < hash_len; i++)
     {
       snprintf (&ascii[i * 2], 3, "%02x", hash[i]);
@@ -176,7 +182,7 @@ split_into_fields (char *dbentry, char *fields[])
  * There are 3 fields:
  *   regular expression to match an input string against
  *   the file to exec to if the regular expression matches
- *   the sha of the file being exec'ed to to verify the file is unchanged since the
+ *   the sha of the file being exec'ed to verify the file is unchanged since the
  *   db was created.
  * Example of a line in the file:
  *   /bin/ping|/usr/bin/ping:/bin/ping:XXXXXX
@@ -295,7 +301,6 @@ kontain_execpath_builddb (execpath_state_t *statep)
 static int
 kontain_execpath_lookup (execpath_state_t *statep, const char *execpath, execpath_entry_t **eppp)
 {
-  int rc;
   struct stat statb;
 
   if (stat (statep->execpath_dbpath, &statb) != 0)

--- a/src/run.c
+++ b/src/run.c
@@ -168,12 +168,14 @@ crun_command_run (struct crun_global_arguments *global_args, int argc, char **ar
   if (UNLIKELY (ret < 0))
     return ret;
 
-  if (crun_context.kontain) {
-    ret = add_kontain_config(container);
-    if (ret != 0) {
-      libcrun_fail_with_error(0, "adding kontain bind mounts");
+  if (crun_context.kontain)
+    {
+      ret = add_kontain_config (container);
+      if (ret != 0)
+        {
+          libcrun_fail_with_error (0, "adding kontain bind mounts");
+        }
     }
-  }
 
   crun_context.bundle = bundle;
   if (getenv ("LISTEN_FDS"))

--- a/tests/alpine-build/Dockerfile
+++ b/tests/alpine-build/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine
 
-RUN apk add gcc automake autoconf libtool gettext pkgconf git make musl-dev \
-    python3 libcap-dev libseccomp-dev yajl-dev argp-standalone go-md2man
+RUN apk add gcc automake autoconf libtool gettext pkgconf git make musl-dev libbsd-dev \
+    python3 libcap-dev libseccomp-dev yajl-dev argp-standalone go-md2man openssl-dev
 
 COPY run-tests.sh /usr/local/bin
 

--- a/tests/centos8-build/Dockerfile
+++ b/tests/centos8-build/Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:8
 
 RUN yum --enablerepo='*' --disablerepo='media-*' install -y make automake autoconf gettext \
-    libtool gcc libcap-devel systemd-devel yajl-devel \
+    libtool gcc libcap-devel systemd-devel yajl-devel openssl-devel \
     libseccomp-devel python36 libtool git
 
 COPY run-tests.sh /usr/local/bin

--- a/tests/clang-check/Dockerfile
+++ b/tests/clang-check/Dockerfile
@@ -1,6 +1,6 @@
 FROM fedora:latest
 
-RUN yum install -y make clang-tools-extra clang python3-pip 'dnf-command(builddep)' && \
+RUN yum install -y make clang-tools-extra clang openssl-devel python3-pip 'dnf-command(builddep)' && \
         dnf builddep -y crun && pip install scan-build
 
 COPY run-tests.sh /usr/local/bin

--- a/tests/containerd/Dockerfile
+++ b/tests/containerd/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
             protobuf-c-compiler libcap-dev libaio-dev \
             curl libprotobuf-c-dev libprotobuf-dev socat libseccomp-dev \
             pigz lsof make git gcc build-essential pkgconf libtool \
-            libsystemd-dev libcap-dev libyajl-dev \
+            libsystemd-dev libcap-dev libyajl-dev libssl-dev \
             go-md2man libtool autoconf python3 automake sudo \
     && update-alternatives --install /usr/bin/go go /usr/lib/go-1.13/bin/go 0 \
     && mkdir -p /root/go/src/github.com/containerd \

--- a/tests/fuzzing/Dockerfile
+++ b/tests/fuzzing/Dockerfile
@@ -1,7 +1,7 @@
 FROM fedora:latest
 
 RUN yum install -y golang python git automake autoconf libcap-devel \
-    systemd-devel yajl-devel libseccomp-devel go-md2man \
+    systemd-devel yajl-devel libseccomp-devel go-md2man openssl-devel \
     glibc-static python3-libmount libtool make honggfuzz git
 
 RUN git clone https://github.com/giuseppe/containers-fuzzing-corpus /testcases

--- a/tests/oci-validation/Dockerfile
+++ b/tests/oci-validation/Dockerfile
@@ -5,7 +5,7 @@ ENV PATH=/usr/bin:/usr/sbin:/root/go/bin:/usr/local/bin::/usr/local/sbin
 
 RUN yum install -y golang python git gcc automake autoconf libcap-devel \
     systemd-devel yajl-devel libseccomp-devel libselinux-devel \
-    glibc-static python3-libmount libtool make npm go-md2man && \
+    glibc-static python3-libmount libtool make npm go-md2man openssl-libs openssl-devel && \
     npm install -g tap
 
 COPY oci-runtime-validation /usr/local/bin

--- a/tests/podman/Dockerfile
+++ b/tests/podman/Dockerfile
@@ -4,7 +4,7 @@ ENV GOPATH=/root/go
 ENV PATH=/usr/bin:/usr/sbin:/root/go/bin:/usr/local/bin::/usr/local/sbin
 
 RUN yum install -y golang python git gcc automake autoconf libcap-devel \
-    systemd-devel yajl-devel libseccomp-devel go-md2man \
+    systemd-devel yajl-devel libseccomp-devel go-md2man openssl-devel \
     glibc-static python3-libmount libtool make podman xz nmap-ncat && \
     dnf install -y 'dnf-command(builddep)' && dnf builddep -y podman && \
     go get github.com/onsi/ginkgo/ginkgo && \

--- a/tests/test_exec.py
+++ b/tests/test_exec.py
@@ -116,8 +116,10 @@ def test_exec_non_km_payload_helper(execpath, nonkmok):
         what executables are allowed to be run without km's help.
     """
 
-    # only run these tests for krun, 77 tests the test controller this test was skipped
+    # only run these tests for krun, 77 tells the test controller this test was skipped
     runtime = os.getenv("OCI_RUNTIME")
+    if runtime is None:
+        return 77
     if os.path.basename(runtime) != "krun":
         return 77
 


### PR DESCRIPTION
These are krun changes needed to cause the crun github workflow to run without error.
Mainly 3 things were done:
- fix coding style to conform to crun style.  The workflow checks coding style.
- add openssl package to the many dockerfiles used by the workflow
- use the BSD queue macros from the libbsd-dev package if available, otherwise use the ones provided with glibc.

With these changes the crun .github/workflows/test.yaml will complete successfully.
There are still problems with .github/workflows/release.yaml that have yet to be addressed.

Fixes #1219 (this issue is in the km repository issues).
When I update km to use the tip of kontainapp/crun, issue 1219 will be closed.